### PR TITLE
CSHARP-2205: OP_MSG type 1 payload support

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Bindings/IChannel.cs
+++ b/src/MongoDB.Driver.Core/Core/Bindings/IChannel.cs
@@ -23,6 +23,7 @@ using MongoDB.Bson.Serialization;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.WireProtocol;
+using MongoDB.Driver.Core.WireProtocol.Messages;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
 
 namespace MongoDB.Driver.Core.Bindings
@@ -104,8 +105,10 @@ namespace MongoDB.Driver.Core.Bindings
         /// <param name="readPreference">The read preference.</param>
         /// <param name="databaseNamespace">The database namespace.</param>
         /// <param name="command">The command.</param>
+        /// <param name="commandPayloads">The command payloads.</param>
         /// <param name="commandValidator">The command validator.</param>
         /// <param name="additionalOptions">The additional options.</param>
+        /// <param name="postWriteAction">The post write action.</param>
         /// <param name="responseHandling">The response handling.</param>
         /// <param name="resultSerializer">The result serializer.</param>
         /// <param name="messageEncoderSettings">The message encoder settings.</param>
@@ -118,9 +121,11 @@ namespace MongoDB.Driver.Core.Bindings
             ReadPreference readPreference,
             DatabaseNamespace databaseNamespace,
             BsonDocument command,
+            IEnumerable<Type1CommandMessageSection> commandPayloads,
             IElementNameValidator commandValidator,
             BsonDocument additionalOptions,
-            Func<CommandResponseHandling> responseHandling,
+            Action<IMessageEncoderPostProcessor> postWriteAction,
+            CommandResponseHandling responseHandling,
             IBsonSerializer<TResult> resultSerializer,
             MessageEncoderSettings messageEncoderSettings,
             CancellationToken cancellationToken);
@@ -189,8 +194,10 @@ namespace MongoDB.Driver.Core.Bindings
         /// <param name="readPreference">The read preference.</param>
         /// <param name="databaseNamespace">The database namespace.</param>
         /// <param name="command">The command.</param>
+        /// <param name="commandPayloads">The command payloads.</param>
         /// <param name="commandValidator">The command validator.</param>
         /// <param name="additionalOptions">The additional options.</param>
+        /// <param name="postWriteAction">The post write action.</param>
         /// <param name="responseHandling">The response handling.</param>
         /// <param name="resultSerializer">The result serializer.</param>
         /// <param name="messageEncoderSettings">The message encoder settings.</param>
@@ -203,9 +210,11 @@ namespace MongoDB.Driver.Core.Bindings
             ReadPreference readPreference,
             DatabaseNamespace databaseNamespace,
             BsonDocument command,
+            IEnumerable<Type1CommandMessageSection> commandPayloads,
             IElementNameValidator commandValidator,
             BsonDocument additionalOptions,
-            Func<CommandResponseHandling> responseHandling,
+            Action<IMessageEncoderPostProcessor> postWriteAction,
+            CommandResponseHandling responseHandling,
             IBsonSerializer<TResult> resultSerializer,
             MessageEncoderSettings messageEncoderSettings,
             CancellationToken cancellationToken);

--- a/src/MongoDB.Driver.Core/Core/Operations/AsyncCursor.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/AsyncCursor.cs
@@ -167,9 +167,11 @@ namespace MongoDB.Driver.Core.Operations
                 null, // readPreference
                 _collectionNamespace.DatabaseNamespace,
                 command,
+                null, // commandPayloads
                 NoOpElementNameValidator.Instance,
                 null, // additionalOptions
-                () => CommandResponseHandling.Return,
+                null, // postWriteAction
+                CommandResponseHandling.Return,
                 __getMoreCommandResultSerializer,
                 _messageEncoderSettings,
                 cancellationToken);
@@ -185,9 +187,11 @@ namespace MongoDB.Driver.Core.Operations
                 null, // readPreference
                 _collectionNamespace.DatabaseNamespace,
                 command,
+                null, // commandPayloads
                 NoOpElementNameValidator.Instance,
                 null, // additionalOptions
-                () => CommandResponseHandling.Return,
+                null, // postWriteAction
+                CommandResponseHandling.Return,
                 __getMoreCommandResultSerializer,
                 _messageEncoderSettings,
                 cancellationToken).ConfigureAwait(false);

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkDeleteOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkDeleteOperation.cs
@@ -34,18 +34,12 @@ namespace MongoDB.Driver.Core.Operations
         // methods
         protected override IRetryableWriteOperation<BsonDocument> CreateBatchOperation(Batch batch)
         {
-            Func<WriteConcern> writeConcernFunc = null;
-            if (!WriteConcern.IsServerDefault)
-            {
-                writeConcernFunc = () => GetBatchWriteConcern(batch);
-            }
-
             return new RetryableDeleteCommandOperation(CollectionNamespace, batch.Requests, MessageEncoderSettings)
             {
                 IsOrdered = IsOrdered,
                 MaxBatchCount = MaxBatchCount,
                 RetryRequested = RetryRequested,
-                WriteConcernFunc = writeConcernFunc
+                WriteConcern = WriteConcern
             };
         }
 

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkInsertOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkInsertOperation.cs
@@ -36,19 +36,13 @@ namespace MongoDB.Driver.Core.Operations
         // methods
         protected override IRetryableWriteOperation<BsonDocument> CreateBatchOperation(Batch batch)
         {
-            Func<WriteConcern> writeConcernFunc = null;
-            if (!WriteConcern.IsServerDefault)
-            {
-                writeConcernFunc = () => GetBatchWriteConcern(batch);
-            }
-
             return new RetryableInsertCommandOperation<InsertRequest>(CollectionNamespace, batch.Requests, InsertRequestSerializer.Instance, MessageEncoderSettings)
             {
                 BypassDocumentValidation = BypassDocumentValidation,
                 IsOrdered = IsOrdered,
                 MaxBatchCount = MaxBatchCount,
                 RetryRequested = RetryRequested,
-                WriteConcernFunc = writeConcernFunc
+                WriteConcern = WriteConcern
             };
         }
 

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkUnmixedWriteOperationBase.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkUnmixedWriteOperationBase.cs
@@ -166,16 +166,6 @@ namespace MongoDB.Driver.Core.Operations
 
         protected abstract IExecutableInRetryableWriteContext<BulkWriteOperationResult> CreateEmulator();
 
-        protected WriteConcern GetBatchWriteConcern(Batch batch)
-        {
-            var writeConcern = _writeConcern;
-            if (!writeConcern.IsAcknowledged && _isOrdered && !batch.Requests.AllItemsWereProcessed)
-            {
-                writeConcern = WriteConcern.W1;
-            }
-            return writeConcern;
-        }
-
         protected abstract bool RequestHasCollation(TWriteRequest request);
 
         // private methods

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkUpdateOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkUpdateOperation.cs
@@ -34,19 +34,13 @@ namespace MongoDB.Driver.Core.Operations
         // methods
         protected override IRetryableWriteOperation<BsonDocument> CreateBatchOperation(Batch batch)
         {
-            Func<WriteConcern> writeConcernFunc = null;
-            if (!WriteConcern.IsServerDefault)
-            {
-                writeConcernFunc = () => GetBatchWriteConcern(batch);
-            }
-
             return new RetryableUpdateCommandOperation(CollectionNamespace, batch.Requests, MessageEncoderSettings)
             {
                 BypassDocumentValidation = BypassDocumentValidation,
                 IsOrdered = IsOrdered,
                 MaxBatchCount = MaxBatchCount,
                 RetryRequested = RetryRequested,
-                WriteConcernFunc = writeConcernFunc
+                WriteConcern = WriteConcern
             };
         }
 

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkWriteBatchResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkWriteBatchResult.cs
@@ -45,7 +45,7 @@ namespace MongoDB.Driver.Core.Operations
             var unprocessedRequests = CreateUnprocessedRequests(requests, writeErrors, isOrdered);
             var upserts = CreateUpserts(writeCommandResponse);
 
-            var n = writeCommandResponse.GetValue("n", 0).ToInt64();
+            var n = writeCommandResponse == null ? 0 : writeCommandResponse.GetValue("n", 0).ToInt64();
             var matchedCount = 0L;
             var deletedCount = 0L;
             var insertedCount = 0L;
@@ -64,7 +64,7 @@ namespace MongoDB.Driver.Core.Operations
                     case WriteRequestType.Update:
                         matchedCount = n - upserts.Count();
                         BsonValue nModified;
-                        if (writeCommandResponse.TryGetValue("nModified", out nModified))
+                        if (writeCommandResponse != null && writeCommandResponse.TryGetValue("nModified", out nModified))
                         {
                             modifiedCount = nModified.ToInt64();
                         }
@@ -248,7 +248,7 @@ namespace MongoDB.Driver.Core.Operations
         {
             var upserts = new List<BulkWriteOperationUpsert>();
 
-            if (writeCommandResponse.Contains("upserted"))
+            if (writeCommandResponse != null && writeCommandResponse.Contains("upserted"))
             {
                 foreach (BsonDocument value in writeCommandResponse["upserted"].AsBsonArray)
                 {
@@ -264,7 +264,7 @@ namespace MongoDB.Driver.Core.Operations
 
         private static BulkWriteConcernError CreateWriteConcernError(BsonDocument writeCommandResponse)
         {
-            if (writeCommandResponse.Contains("writeConcernError"))
+            if (writeCommandResponse != null && writeCommandResponse.Contains("writeConcernError"))
             {
                 var value = (BsonDocument)writeCommandResponse["writeConcernError"];
                 var code = value["code"].ToInt32();
@@ -311,7 +311,7 @@ namespace MongoDB.Driver.Core.Operations
         {
             var writeErrors = new List<BulkWriteOperationError>();
 
-            if (writeCommandResponse.Contains("writeErrors"))
+            if (writeCommandResponse != null && writeCommandResponse.Contains("writeErrors"))
             {
                 foreach (BsonDocument value in writeCommandResponse["writeErrors"].AsBsonArray)
                 {

--- a/src/MongoDB.Driver.Core/Core/Operations/CommandOperationBase.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/CommandOperationBase.cs
@@ -153,9 +153,11 @@ namespace MongoDB.Driver.Core.Operations
                 readPreference,
                 _databaseNamespace,
                 _command,
+                null, // commandPayloads
                 _commandValidator,
                 additionalOptions,
-                () => CommandResponseHandling.Return,
+                null, // postWriteAction,
+                CommandResponseHandling.Return,
                 _resultSerializer,
                 _messageEncoderSettings,
                 cancellationToken);
@@ -192,9 +194,11 @@ namespace MongoDB.Driver.Core.Operations
                 readPreference,
                 _databaseNamespace,
                 _command,
+                null, // TODO: support commandPayloads
                 _commandValidator,
                 additionalOptions,
-                () => CommandResponseHandling.Return,
+                null, // postWriteAction,
+                CommandResponseHandling.Return,
                 _resultSerializer,
                 _messageEncoderSettings,
                 cancellationToken);

--- a/src/MongoDB.Driver.Core/Core/Servers/Server.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/Server.cs
@@ -34,6 +34,7 @@ using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Operations;
 using MongoDB.Driver.Core.WireProtocol;
+using MongoDB.Driver.Core.WireProtocol.Messages;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
 
 namespace MongoDB.Driver.Core.Servers
@@ -322,17 +323,26 @@ namespace MongoDB.Driver.Core.Servers
                 CancellationToken cancellationToken)
             {
                 var readPreference = GetEffectiveReadPreference(slaveOk, null);
-                return Command(
+                var result = Command(
                     NoCoreSession.Instance,
                     readPreference,
                     databaseNamespace,
                     command,
+                    null, // commandPayloads
                     commandValidator,
                     null, // additionalOptions
-                    responseHandling,
+                    null, // postWriteAction
+                    CommandResponseHandling.Return,
                     resultSerializer,
                     messageEncoderSettings,
                     cancellationToken);
+
+                if (responseHandling != null && responseHandling() != CommandResponseHandling.Return)
+                {
+                    throw new NotSupportedException("This overload requires responseHandling to be: Return.");
+                }
+
+                return result;
             }
 
             [Obsolete("Use the newest overload instead.")]
@@ -350,17 +360,26 @@ namespace MongoDB.Driver.Core.Servers
                 CancellationToken cancellationToken)
             {
                 readPreference = GetEffectiveReadPreference(slaveOk, readPreference);
-                return Command(
+                var result = Command(
                     session,
                     readPreference,
                     databaseNamespace,
                     command,
+                    null, // commandPayloads
                     commandValidator,
                     additionalOptions,
-                    responseHandling,
+                    null, // postWriteActions
+                    CommandResponseHandling.Return,
                     resultSerializer,
                     messageEncoderSettings,
                     cancellationToken);
+
+                if (responseHandling != null && responseHandling() != CommandResponseHandling.Return)
+                {
+                    throw new NotSupportedException("This overload requires responseHandling to be: Return.");
+                }
+
+                return result;
             }
 
             public TResult Command<TResult>(
@@ -368,9 +387,11 @@ namespace MongoDB.Driver.Core.Servers
                 ReadPreference readPreference,
                 DatabaseNamespace databaseNamespace,
                 BsonDocument command,
+                IEnumerable<Type1CommandMessageSection> commandPayloads,
                 IElementNameValidator commandValidator,
                 BsonDocument additionalOptions,
-                Func<CommandResponseHandling> responseHandling,
+                Action<IMessageEncoderPostProcessor> postWriteAction,
+                CommandResponseHandling responseHandling,
                 IBsonSerializer<TResult> resultSerializer,
                 MessageEncoderSettings messageEncoderSettings,
                 CancellationToken cancellationToken)
@@ -380,8 +401,10 @@ namespace MongoDB.Driver.Core.Servers
                     readPreference,
                     databaseNamespace,
                     command,
+                    commandPayloads,
                     commandValidator,
                     additionalOptions,
+                    postWriteAction,
                     responseHandling,
                     resultSerializer,
                     messageEncoderSettings);
@@ -401,17 +424,26 @@ namespace MongoDB.Driver.Core.Servers
                 CancellationToken cancellationToken)
             {
                 var readPreference = GetEffectiveReadPreference(slaveOk, null);
-                return CommandAsync(
+                var result = CommandAsync(
                     NoCoreSession.Instance,
                     readPreference,
                     databaseNamespace,
                     command,
+                    null, // commandPayloads
                     commandValidator,
                     null, // additionalOptions
-                    responseHandling,
+                    null, // postWriteAction
+                    CommandResponseHandling.Return,
                     resultSerializer,
                     messageEncoderSettings,
                     cancellationToken);
+
+                if (responseHandling != null && responseHandling() != CommandResponseHandling.Return)
+                {
+                    throw new NotSupportedException("This overload requires responseHandling to be 'Return'.");
+                }
+
+                return result;
             }
 
             [Obsolete("Use the newest overload instead.")]
@@ -429,17 +461,26 @@ namespace MongoDB.Driver.Core.Servers
                 CancellationToken cancellationToken)
             {
                 readPreference = GetEffectiveReadPreference(slaveOk, readPreference);
-                return CommandAsync(
+                var result = CommandAsync(
                     session,
                     readPreference,
                     databaseNamespace,
                     command,
+                    null, // commandPayloads
                     commandValidator,
                     additionalOptions,
-                    responseHandling,
+                    null, // postWriteAction
+                    CommandResponseHandling.Return,
                     resultSerializer,
                     messageEncoderSettings,
                     cancellationToken);
+
+                if (responseHandling != null && responseHandling() != CommandResponseHandling.Return)
+                {
+                    throw new NotSupportedException("This overload requires responseHandling to be 'Return'.");
+                }
+
+                return result;
             }
 
             public Task<TResult> CommandAsync<TResult>(
@@ -447,9 +488,11 @@ namespace MongoDB.Driver.Core.Servers
                 ReadPreference readPreference,
                 DatabaseNamespace databaseNamespace,
                 BsonDocument command,
+                IEnumerable<Type1CommandMessageSection> commandPayloads,
                 IElementNameValidator commandValidator,
                 BsonDocument additionalOptions,
-                Func<CommandResponseHandling> responseHandling,
+                Action<IMessageEncoderPostProcessor> postWriteAction,
+                CommandResponseHandling responseHandling,
                 IBsonSerializer<TResult> resultSerializer,
                 MessageEncoderSettings messageEncoderSettings,
                 CancellationToken cancellationToken)
@@ -459,8 +502,10 @@ namespace MongoDB.Driver.Core.Servers
                     readPreference,
                     databaseNamespace,
                     command,
+                    commandPayloads,
                     commandValidator,
                     additionalOptions,
+                    postWriteAction,
                     responseHandling,
                     resultSerializer,
                     messageEncoderSettings);

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CommandMessage.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CommandMessage.cs
@@ -28,7 +28,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
     public sealed class CommandMessage : MongoDBMessage
     {
         // fields
-        private readonly bool _moreToCome;
+        private bool _moreToCome;
+        private Action<IMessageEncoderPostProcessor> _postWriteAction;
         private readonly int _requestId;
         private readonly int _responseTo;
         private readonly List<CommandMessageSection> _sections;
@@ -42,8 +43,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
         /// <param name="sections">The sections.</param>
         /// <param name="moreToCome">if set to <c>true</c> [more to come].</param>
         public CommandMessage(
-            int requestId, 
-            int responseTo, 
+            int requestId,
+            int responseTo,
             IEnumerable<CommandMessageSection> sections,
             bool moreToCome)
         {
@@ -63,12 +64,28 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
         public override MongoDBMessageType MessageType => MongoDBMessageType.Command;
 
         /// <summary>
-        /// Gets a value indicating whether another message immediately follows this one.
+        /// Gets or sets a value indicating whether another message immediately follows this one with no response expected.
         /// </summary>
         /// <value>
         ///   <c>true</c> if another message immediately follows this one; otherwise, <c>false</c>.
         /// </value>
-        public bool MoreToCome => _moreToCome;
+        public bool MoreToCome
+        {
+            get { return _moreToCome; }
+            set { _moreToCome = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the delegate called to after the message has been written by the encoder.
+        /// </summary>
+        /// <value>
+        /// The post write delegate.
+        /// </value>
+        public Action<IMessageEncoderPostProcessor> PostWriteAction
+        {
+            get { return _postWriteAction; }
+            set { _postWriteAction = value; }
+        }
 
         /// <summary>
         /// Gets the request identifier.
@@ -77,6 +94,14 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
         /// The request identifier.
         /// </value>
         public int RequestId => _requestId;
+
+        /// <summary>
+        /// Gets a value indicating whether a response is expected.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if a response is expected; otherwise, <c>false</c>.
+        /// </value>
+        public bool ResponseExpected => !_moreToCome;
 
         /// <summary>
         /// Gets the response to.

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/MessageBinaryEncoderBase.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/MessageBinaryEncoderBase.cs
@@ -69,6 +69,20 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         }
 
         /// <summary>
+        /// Gets the maximum size of the document.
+        /// </summary>
+        /// <value>
+        /// The maximum size of the document.
+        /// </value>
+        protected int? MaxDocumentSize
+        {
+            get
+            {
+                return _encoderSettings?.GetOrDefault<int?>(MessageEncoderSettingsName.MaxDocumentSize, null);
+            }
+        }
+
+        /// <summary>
         /// Gets the maximum size of the message.
         /// </summary>
         /// <value>
@@ -78,7 +92,21 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         {
             get
             {
-                return _encoderSettings.GetOrDefault<int?>(MessageEncoderSettingsName.MaxMessageSize, null);
+                return _encoderSettings?.GetOrDefault<int?>(MessageEncoderSettingsName.MaxMessageSize, null);
+            }
+        }
+
+        /// <summary>
+        /// Gets the maximum size of the wire document.
+        /// </summary>
+        /// <value>
+        /// The maximum size of the wire document.
+        /// </value>
+        protected int? MaxWireDocumentSize
+        {
+            get
+            {
+                return _encoderSettings?.GetOrDefault<int?>(MessageEncoderSettingsName.MaxWireDocumentSize, null);
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/OpMsgFlags.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/OpMsgFlags.cs
@@ -20,7 +20,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
     [Flags]
     internal enum OpMsgFlags
     {
-        MoreToCome = 1,
-        All = 1
+        ChecksumPresent = 1,
+        MoreToCome = 2,
+        All = 3
     }
 }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/QueryMessageBinaryEncoder.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/QueryMessageBinaryEncoder.cs
@@ -135,7 +135,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
 
             var binaryWriter = CreateBinaryWriter();
             var stream = binaryWriter.BsonStream;
-            var startPosition = stream.Position;
+            var messageStartPosition = stream.Position;
 
             stream.WriteInt32(0); // messageSize
             stream.WriteInt32(message.RequestId);
@@ -147,9 +147,12 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             stream.WriteInt32(message.BatchSize);
             WriteQuery(binaryWriter, message.Query, message.QueryValidator);
             WriteOptionalFields(binaryWriter, message.Fields);
-            stream.BackpatchSize(startPosition);
+            stream.BackpatchSize(messageStartPosition);
+
+            message.PostWriteAction?.Invoke(new PostProcessor(message, stream, messageStartPosition));
         }
 
+        // private methods
         private void WriteOptionalFields(BsonBinaryWriter binaryWriter, BsonDocument fields)
         {
             if (fields != null)
@@ -161,6 +164,9 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
 
         private void WriteQuery(BsonBinaryWriter binaryWriter, BsonDocument query, IElementNameValidator queryValidator)
         {
+            var maxWireDocumentSize = MaxWireDocumentSize ?? MaxDocumentSize ?? binaryWriter.Settings.MaxDocumentSize;
+
+            binaryWriter.PushSettings(s => ((BsonBinaryWriterSettings)s).MaxDocumentSize = maxWireDocumentSize);
             binaryWriter.PushElementNameValidator(queryValidator);
             try
             {
@@ -170,6 +176,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             finally
             {
                 binaryWriter.PopElementNameValidator();
+                binaryWriter.PopSettings();
             }
         }
 
@@ -185,6 +192,96 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         }
 
         // nested types
+        private class PostProcessor : IMessageEncoderPostProcessor
+        {
+            // private fields
+            private readonly QueryMessage _message;
+            private readonly long _messageStartPosition;
+            private readonly BsonStream _stream;
+
+            // constructors
+            public PostProcessor(QueryMessage message, BsonStream stream, long messageStartPosition)
+            {
+                _message = message;
+                _stream = stream;
+                _messageStartPosition = messageStartPosition;
+            }
+
+            // public methods
+            public void ChangeWriteConcernFromW0ToW1()
+            {
+                ChangeWFrom0To1();
+                _message.ResponseHandling = CommandResponseHandling.Return;
+            }
+
+            // private methods
+            private void ChangeWFrom0To1()
+            {
+                var wPosition = FindWPosition();
+                _stream.Position = wPosition;
+                var w = _stream.ReadInt32();
+                if (w != 0)
+                {
+                    throw new InvalidOperationException("w was not 0.");
+                }
+                _stream.Position = wPosition;
+                _stream.WriteInt32(1);
+            }
+
+            private long FindWPosition()
+            {
+                _stream.Position = _messageStartPosition + 20;
+                _stream.SkipCString();
+                _stream.Position += 8;
+
+                using (var reader = new BsonBinaryReader(_stream))
+                {
+                    return FindWPosition(reader, false);
+                }
+            }
+
+            private long FindWPosition(BsonBinaryReader reader, bool alreadyUnwrapped)
+            {
+                reader.ReadStartDocument();
+                while (reader.ReadBsonType() != 0)
+                {
+                    var name = reader.ReadName();
+                    if (name == "writeConcern")
+                    {
+                        reader.ReadStartDocument();
+                        while (reader.ReadBsonType() != 0)
+                        {
+                            if (reader.ReadName() == "w")
+                            {
+                                if (reader.CurrentBsonType == BsonType.Int32)
+                                {
+                                    return _stream.Position;
+                                }
+                                else
+                                {
+                                    goto notFound;
+                                }
+                            }
+                            else
+                            {
+                                reader.SkipValue();
+                            }
+                        }
+                        goto notFound;
+                    }
+                    else if (name == "$query" && !alreadyUnwrapped)
+                    {
+                        return FindWPosition(reader, true);
+                    }
+
+                    reader.SkipValue();
+                }
+
+                notFound:
+                throw new InvalidOperationException("{ w : <Int32> } not found.");
+            }
+        }
+
         [Flags]
         private enum QueryFlags
         {

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/IMessageEncoderPostProcessor.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/IMessageEncoderPostProcessor.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2013-present MongoDB Inc.
+﻿/* Copyright 2018-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -13,31 +13,16 @@
 * limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using MongoDB.Driver.Core.Misc;
-
-namespace MongoDB.Driver.Core.WireProtocol
+namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders
 {
     /// <summary>
-    /// Instructions for handling the response from a command.
+    /// Represents the changes that can be made to a message after it has been encoded.
     /// </summary>
-    public enum CommandResponseHandling
+    public interface IMessageEncoderPostProcessor
     {
         /// <summary>
-        /// Return the response from the server.
+        /// Changes the write concern from w0 to w1.
         /// </summary>
-        Return,
-        /// <summary>
-        /// Ignore the response from the server.
-        /// </summary>
-        Ignore,
-        /// <summary>
-        /// No response is expected from the server.
-        /// </summary>
-        NoResponseExpected
+        void ChangeWriteConcernFromW0ToW1();
     }
 }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/JsonEncoders/CommandMessageJsonEncoder.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/JsonEncoders/CommandMessageJsonEncoder.cs
@@ -140,7 +140,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.JsonEncoders
             var identifier = sectionDocument["identifier"].AsString;
             var documents = sectionDocument["documents"].AsBsonArray.Cast<BsonDocument>().ToList();
             var batch = new BatchableSource<BsonDocument>(documents, canBeSplit: false);
-            return new Type1CommandMessageSection<BsonDocument>(identifier, batch, BsonDocumentSerializer.Instance);
+            return new Type1CommandMessageSection<BsonDocument>(identifier, batch, BsonDocumentSerializer.Instance, NoOpElementNameValidator.Instance, null, null);
         }
 
         private void WriteSection(IBsonWriter writer, CommandMessageSection section)

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/MessageEncoderSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/MessageEncoderSettings.cs
@@ -64,6 +64,11 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders
         public const string MaxSerializationDepth = "MaxSerializationDepth";
 
         /// <summary>
+        /// The maximum wire document size.
+        /// </summary>
+        public const string MaxWireDocumentSize = nameof(MaxWireDocumentSize);
+
+        /// <summary>
         /// The name of the ReadEncoding setting.
         /// </summary>
         public const string ReadEncoding = "ReadEncoding";
@@ -122,6 +127,20 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders
         {
             _settings.Add(name, value);
             return this;
+        }
+
+        /// <summary>
+        /// Clones this instance.
+        /// </summary>
+        /// <returns>The clone.</returns>
+        public MessageEncoderSettings Clone()
+        {
+            var clone = new MessageEncoderSettings();
+            foreach (var key in _settings.Keys)
+            {
+                clone.Add(key, _settings[key]);
+            }
+            return clone;
         }
 
         /// <inheritdoc/>

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/QueryMessage.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/QueryMessage.cs
@@ -35,15 +35,17 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
         private readonly bool _noCursorTimeout;
         private readonly bool _oplogReplay;
         private readonly bool _partialOk;
+        private Action<IMessageEncoderPostProcessor> _postWriteAction;
         private readonly BsonDocument _query;
         private readonly IElementNameValidator _queryValidator;
+        private CommandResponseHandling _responseHandling = CommandResponseHandling.Return;
         private readonly int _skip;
         private readonly bool _slaveOk;
         private readonly bool _tailableCursor;
 
         // constructors
         /// <summary>
-        /// Initializes a new instance of the <see cref="QueryMessage"/> class.
+        /// Initializes a new instance of the <see cref="QueryMessage" /> class.
         /// </summary>
         /// <param name="requestId">The request identifier.</param>
         /// <param name="collectionNamespace">The collection namespace.</param>
@@ -157,6 +159,18 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
         }
 
         /// <summary>
+        /// Gets or sets the delegate called to after the message has been written by the encoder.
+        /// </summary>
+        /// <value>
+        /// The post write delegate.
+        /// </value>
+        public Action<IMessageEncoderPostProcessor> PostWriteAction
+        {
+            get { return _postWriteAction; }
+            set { _postWriteAction = value; }
+        }
+
+        /// <summary>
         /// Gets the query.
         /// </summary>
         public BsonDocument Query
@@ -170,6 +184,25 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
         public IElementNameValidator QueryValidator
         {
             get { return _queryValidator; }
+        }
+
+        /// <summary>
+        /// Gets or sets the response handling.
+        /// </summary>
+        /// <value>
+        /// The response handling.
+        /// </value>
+        public CommandResponseHandling ResponseHandling
+        {
+            get { return _responseHandling; }
+            set
+            {
+                if (value != CommandResponseHandling.Return && value != CommandResponseHandling.Ignore)
+                {
+                    throw new ArgumentException("CommandResponseHandling must be Return or Ignore.", nameof(value));
+                }
+                _responseHandling = value;
+            }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CommandRequestMessageBinaryEncoder.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CommandResponseMessageBinaryEncoder.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\CommandResponseMessageEncoderSelector.cs" />
+    <Compile Include="Core\WireProtocol\Messages\Encoders\IMessageEncoderPostProcessor.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\JsonEncoders\CommandMessageJsonEncoder.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\JsonEncoders\CommandRequestMessageJsonEncoder.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\JsonEncoders\CommandResponseMessageJsonEncoder.cs" />

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/ElementAppendingSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/ElementAppendingSerializerTests.cs
@@ -189,7 +189,8 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         public void Serialize_should_configure_GuidRepresentation(bool useGenericInterface)
         {
             var mockDocumentSerializer = new Mock<IBsonSerializer<BsonDocument>>();
-            var subject = new ElementAppendingSerializer<BsonDocument>(mockDocumentSerializer.Object, new BsonElement[0]);
+            var writerSettingsConfigurator = (Action<BsonWriterSettings>)(s => s.GuidRepresentation = GuidRepresentation.Unspecified);
+            var subject = new ElementAppendingSerializer<BsonDocument>(mockDocumentSerializer.Object, new BsonElement[0], writerSettingsConfigurator);
             var stream = new MemoryStream();
             var settings = new BsonBinaryWriterSettings { GuidRepresentation = GuidRepresentation.CSharpLegacy };
             var writer = new BsonBinaryWriter(stream, settings);
@@ -255,11 +256,14 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         }
 
         // private methods
-        private ElementAppendingSerializer<BsonDocument> CreateSubject(IEnumerable<BsonElement> elements = null)
+        private ElementAppendingSerializer<BsonDocument> CreateSubject(
+            IEnumerable<BsonElement> elements = null,
+            Action<BsonWriterSettings> writerSettingsConfigurator = null)
         {
             var documentSerializer = BsonDocumentSerializer.Instance;
             elements = elements ?? new BsonElement[0];
-            return new ElementAppendingSerializer<BsonDocument>(documentSerializer, elements);
+            writerSettingsConfigurator = writerSettingsConfigurator ?? (s => s.GuidRepresentation = GuidRepresentation.Unspecified);
+            return new ElementAppendingSerializer<BsonDocument>(documentSerializer, elements, writerSettingsConfigurator);
         }
     }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/AsyncCursorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/AsyncCursorTests.cs
@@ -233,9 +233,11 @@ namespace MongoDB.Driver.Core.Operations
                         null,
                         databaseNamespace,
                         It.IsAny<BsonDocument>(),
+                        null,
                         NoOpElementNameValidator.Instance,
                         null,
-                        It.IsAny<Func<CommandResponseHandling>>(),
+                        null,
+                        CommandResponseHandling.Return,
                         It.IsAny<IBsonSerializer<BsonDocument>>(),
                         It.IsAny<MessageEncoderSettings>(),
                         cancellationToken))
@@ -253,9 +255,11 @@ namespace MongoDB.Driver.Core.Operations
                         null,
                         databaseNamespace,
                         It.IsAny<BsonDocument>(),
+                        null,
                         NoOpElementNameValidator.Instance,
                         null,
-                        It.IsAny<Func<CommandResponseHandling>>(),
+                        null,
+                        CommandResponseHandling.Return,
                         It.IsAny<IBsonSerializer<BsonDocument>>(),
                         It.IsAny<MessageEncoderSettings>(),
                         cancellationToken))
@@ -386,9 +390,11 @@ namespace MongoDB.Driver.Core.Operations
                 ReadPreference.Primary,
                 _databaseNamespace,
                 command,
+                null, // payloads
                 NoOpElementNameValidator.Instance,
                 null, // additionalOptions
-                () => CommandResponseHandling.Return,
+                null, // postWriteAction
+                CommandResponseHandling.Return,
                 BsonDocumentSerializer.Instance,
                 _messageEncoderSettings,
                 cancellationToken);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
@@ -1291,11 +1291,9 @@ namespace MongoDB.Driver.Core.Operations
         [SkippableTheory]
         [InlineData(new[] { 1 }, new[] { 1 })]
         [InlineData(new[] { 1, 1 }, new[] { 2 })]
-        [InlineData(new[] { 8388605, 8388605 }, new[] { 2 })]
-        [InlineData(new[] { 8388605, 8388606 }, new[] { 1, 1 })]
-        [InlineData(new[] { 16777216 }, new[] { 1 })]
-        [InlineData(new[] { 16777216, 1 }, new[] { 1, 1 })]
-        [InlineData(new[] { 16777216, 16777216 }, new[] { 1, 1 })]
+        [InlineData(new[] { 10000000, 10000000, 10000000, 10000000 }, new[] { 4 })]
+        [InlineData(new[] { 10000000, 10000000, 10000000, 10000000, 7999887 }, new[] { 5 })]
+        [InlineData(new[] { 10000000, 10000000, 10000000, 10000000, 7999888 }, new[] { 4, 1 })]
         public void Execute_with_multiple_deletes_should_split_batches_as_expected_when_using_write_commands_via_opmessage(int[] requestSizes, int[] expectedBatchCounts)
         {
             RequireServer.Check().Supports(Feature.WriteCommands, Feature.CommandMessage);
@@ -1356,11 +1354,9 @@ namespace MongoDB.Driver.Core.Operations
         [SkippableTheory]
         [InlineData(new[] { 1 }, new[] { 1 })]
         [InlineData(new[] { 1, 1 }, new[] { 2 })]
-        [InlineData(new[] { 8388605, 8388605 }, new[] { 2 })]
-        [InlineData(new[] { 8388605, 8388606 }, new[] { 1, 1 })]
-        [InlineData(new[] { 16777216 }, new[] { 1 })]
-        [InlineData(new[] { 16777216, 1 }, new[] { 1, 1 })]
-        [InlineData(new[] { 16777216, 16777216 }, new[] { 1, 1 })]
+        [InlineData(new[] { 10000000, 10000000, 10000000, 10000000 }, new[] { 4 })]
+        [InlineData(new[] { 10000000, 10000000, 10000000, 10000000, 7999885 }, new[] { 5 })]
+        [InlineData(new[] { 10000000, 10000000, 10000000, 10000000, 7999886 }, new[] { 4, 1 })]
         public void Execute_with_multiple_inserts_should_split_batches_as_expected_when_using_write_commands_via_opmessage(int[] documentSizes, int[] expectedBatchCounts)
         {
             RequireServer.Check().Supports(Feature.WriteCommands, Feature.CommandMessage);
@@ -1424,11 +1420,9 @@ namespace MongoDB.Driver.Core.Operations
         [SkippableTheory]
         [InlineData(new[] { 1 }, new[] { 1 })]
         [InlineData(new[] { 1, 1 }, new[] { 2 })]
-        [InlineData(new[] { 8388605, 8388605 }, new[] { 2 })]
-        [InlineData(new[] { 8388605, 8388606 }, new[] { 1, 1 })]
-        [InlineData(new[] { 16777216 }, new[] { 1 })]
-        [InlineData(new[] { 16777216, 1 }, new[] { 1, 1 })]
-        [InlineData(new[] { 16777216, 16777216 }, new[] { 1, 1 })]
+        [InlineData(new[] { 10000000, 10000000, 10000000, 10000000 }, new[] { 4 })]
+        [InlineData(new[] { 10000000, 10000000, 10000000, 10000000, 7999887 }, new[] { 5 })]
+        [InlineData(new[] { 10000000, 10000000, 10000000, 10000000, 7999888 }, new[] { 4, 1 })]
         public void Execute_with_multiple_updates_should_split_batches_as_expected_when_using_write_commands_via_opmessage(int[] requestSizes, int[] expectedBatchCounts)
         {
             RequireServer.Check().Supports(Feature.WriteCommands, Feature.CommandMessage);
@@ -1542,7 +1536,7 @@ namespace MongoDB.Driver.Core.Operations
                 BsonDocument.Parse("{_id: 5, x: 2 }"),
                 BsonDocument.Parse("{_id: 6, x: 3 }"));
         }
-        
+
         private List<BsonDocument> ReadAllFromCollection(IReadBinding binding)
         {
             var operation = new FindOperation<BsonDocument>(_collectionNamespace, BsonDocumentSerializer.Instance, _messageEncoderSettings);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/ReadCommandOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/ReadCommandOperationTests.cs
@@ -90,9 +90,11 @@ namespace MongoDB.Driver.Core.Operations
                         readPreference,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         null, // additionalOptions
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -108,9 +110,11 @@ namespace MongoDB.Driver.Core.Operations
                         readPreference,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         null, // additionalOptions
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -145,9 +149,11 @@ namespace MongoDB.Driver.Core.Operations
                         readPreference,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         additionalOptions,
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -163,9 +169,11 @@ namespace MongoDB.Driver.Core.Operations
                         readPreference,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         additionalOptions,
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -199,9 +207,11 @@ namespace MongoDB.Driver.Core.Operations
                         readPreference,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         additionalOptions,
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -217,9 +227,11 @@ namespace MongoDB.Driver.Core.Operations
                         readPreference,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         additionalOptions,
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -254,9 +266,11 @@ namespace MongoDB.Driver.Core.Operations
                         readPreference,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         additionalOptions,
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -272,9 +286,11 @@ namespace MongoDB.Driver.Core.Operations
                         readPreference,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         additionalOptions,
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/WriteCommandOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/WriteCommandOperationTests.cs
@@ -78,9 +78,11 @@ namespace MongoDB.Driver.Core.Operations
                         ReadPreference.Primary,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         null, // additionalOptions
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -96,9 +98,11 @@ namespace MongoDB.Driver.Core.Operations
                         ReadPreference.Primary,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         null, // additionalOptions
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -131,9 +135,11 @@ namespace MongoDB.Driver.Core.Operations
                         It.IsAny<ReadPreference>(),
                         subject.DatabaseNamespace,
                         command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         subject.AdditionalOptions,
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -149,9 +155,11 @@ namespace MongoDB.Driver.Core.Operations
                         It.IsAny<ReadPreference>(),
                         subject.DatabaseNamespace,
                         command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         subject.AdditionalOptions,
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -184,9 +192,11 @@ namespace MongoDB.Driver.Core.Operations
                         ReadPreference.Primary,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         additionalOptions,
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),
@@ -202,9 +212,11 @@ namespace MongoDB.Driver.Core.Operations
                         ReadPreference.Primary,
                         subject.DatabaseNamespace,
                         subject.Command,
+                        null, // commandPayloads
                         subject.CommandValidator,
                         additionalOptions,
-                        It.Is<Func<CommandResponseHandling>>(f => f() == CommandResponseHandling.Return),
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         subject.ResultSerializer,
                         subject.MessageEncoderSettings,
                         cancellationToken),

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerTests.cs
@@ -285,9 +285,11 @@ namespace MongoDB.Driver.Core.Servers
                             ReadPreference.Primary,
                             DatabaseNamespace.Admin,
                             command,
+                            null, // payloads
                             NoOpElementNameValidator.Instance,
                             null, // additionalOptions
-                            () => CommandResponseHandling.Return,
+                            null, // postWriteAction
+                            CommandResponseHandling.Return,
                             BsonDocumentSerializer.Instance,
                             new MessageEncoderSettings(),
                             cancellationToken);
@@ -326,9 +328,11 @@ namespace MongoDB.Driver.Core.Servers
                         ReadPreference.Primary,
                         DatabaseNamespace.Admin,
                         command,
+                        null, // payloads
                         NoOpElementNameValidator.Instance,
                         null, // additionalOptions
-                        () => CommandResponseHandling.Return,
+                        null, // postWriteAction
+                        CommandResponseHandling.Return,
                         BsonDocumentSerializer.Instance,
                         new MessageEncoderSettings(),
                         cancellationToken);

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/CommandWriteProtocolTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/CommandWriteProtocolTests.cs
@@ -46,9 +46,11 @@ namespace MongoDB.Driver.Core.WireProtocol
                 ReadPreference.Primary,
                 new DatabaseNamespace("test"),
                 new BsonDocument("cmd", 1),
+                null, // commandPayloads
                 NoOpElementNameValidator.Instance,
                 null, // additionalOptions
-                () => CommandResponseHandling.Return,
+                null, // postWriteAction
+                CommandResponseHandling.Return,
                 BsonDocumentSerializer.Instance,
                 messageEncoderSettings);
 
@@ -64,7 +66,7 @@ namespace MongoDB.Driver.Core.WireProtocol
         }
 
         [Fact]
-        public void Execute_should_not_wait_for_response_when_CommandResponseHandling_is_Ignore()
+        public void Execute_should_not_wait_for_response_when_CommandResponseHandling_is_NoResponseExpected()
         {
             var messageEncoderSettings = new MessageEncoderSettings();
             var subject = new CommandWireProtocol<BsonDocument>(
@@ -72,9 +74,11 @@ namespace MongoDB.Driver.Core.WireProtocol
                 ReadPreference.Primary,
                 new DatabaseNamespace("test"),
                 new BsonDocument("cmd", 1),
+                null, // commandPayloads
                 NoOpElementNameValidator.Instance,
                 null, // additionalOptions
-                () => CommandResponseHandling.Ignore,
+                null, // postWriteAction
+                CommandResponseHandling.NoResponseExpected,
                 BsonDocumentSerializer.Instance,
                 messageEncoderSettings);
 
@@ -97,9 +101,11 @@ namespace MongoDB.Driver.Core.WireProtocol
                 ReadPreference.Primary,
                 new DatabaseNamespace("test"),
                 new BsonDocument("cmd", 1),
+                null, // commandPayloads
                 NoOpElementNameValidator.Instance,
                 null, // additionalOptions
-                () => CommandResponseHandling.Return,
+                null, // postWriteAction
+                CommandResponseHandling.Return,
                 BsonDocumentSerializer.Instance,
                 messageEncoderSettings);
 
@@ -115,7 +121,7 @@ namespace MongoDB.Driver.Core.WireProtocol
         }
 
         [Fact]
-        public void ExecuteAsync_should_not_wait_for_response_when_CommandResponseHandling_is_Ignore()
+        public void ExecuteAsync_should_not_wait_for_response_when_CommandResponseHandling_is_NoResponseExpected()
         {
             var messageEncoderSettings = new MessageEncoderSettings();
             var subject = new CommandWireProtocol<BsonDocument>(
@@ -123,9 +129,11 @@ namespace MongoDB.Driver.Core.WireProtocol
                 ReadPreference.Primary,
                 new DatabaseNamespace("test"),
                 new BsonDocument("cmd", 1),
+                null, // commandPayloads
                 NoOpElementNameValidator.Instance,
                 null, // additionalOptions
-                () => CommandResponseHandling.Ignore,
+                null, // postWriteAction
+                CommandResponseHandling.NoResponseExpected,
                 BsonDocumentSerializer.Instance,
                 messageEncoderSettings);
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/JsonEncoders/CommandMessageJsonEncoderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/JsonEncoders/CommandMessageJsonEncoderTests.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
+using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Misc;
@@ -443,7 +444,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.JsonEncoders
             identifier = identifier ?? "id";
             documents = documents ?? new BsonDocument[0];
             var batch = new BatchableSource<BsonDocument>(documents, canBeSplit: false);
-            return new Type1CommandMessageSection<BsonDocument>(identifier, batch, BsonDocumentSerializer.Instance);
+            return new Type1CommandMessageSection<BsonDocument>(identifier, batch, BsonDocumentSerializer.Instance, NoOpElementNameValidator.Instance, null, null);
         }
 
         private BsonDocument CreateType1SectionDocument(Type1CommandMessageSection<BsonDocument> section)


### PR DESCRIPTION
Besides adding type 1 payload support to OP_MSG this change emulates payloads when using OP_QUERY by inserting the payloads directly into the command.