### PR TITLE
Update release notes for 2.5.1.

### DIFF
--- a/Release Notes/Release Notes v2.5.1.md
+++ b/Release Notes/Release Notes v2.5.1.md
@@ -1,3 +1,19 @@
 # .NET Driver Version 2.5.1 Release Notes
 
-This file is a placeholder.
+This is a patch release that fixes a few bugs reported since 2.5.0 was released.
+
+An online version of these release notes is available at:
+
+https://github.com/mongodb/mongo-csharp-driver/blob/master/Release%20Notes/Release%20Notes%20v2.5.1.md
+
+The full list of JIRA issues resolved in this release is available at:
+
+https://jira.mongodb.org/issues/?jql=project%20%3D%20CSHARP%20AND%20fixVersion%20%3D%202.5.1%20ORDER%20BY%20key%20ASC
+
+Documentation on the .NET driver can be found at:
+
+http://mongodb.github.io/mongo-csharp-driver/
+
+Upgrading
+
+There are no known backwards breaking changes in this release.


### PR DESCRIPTION
This is the same as release notes we've used for 2.4.x patch releases.

I don't think we need any more detail, do we?