### PR TITLE
CSHARP-2260: MongoNodeIsRecoveringException message should include actual error code and codeName.

### DIFF
--- a/src/MongoDB.Driver.Core/MongoNodeIsRecoveringException.cs
+++ b/src/MongoDB.Driver.Core/MongoNodeIsRecoveringException.cs
@@ -32,6 +32,24 @@ namespace MongoDB.Driver
 #endif
     public class MongoNodeIsRecoveringException : MongoServerException
     {
+        #region static
+        // private static methods
+        private static string CreateMessage(BsonDocument result)
+        {
+            var code = result.GetValue("code", -1).ToInt32();
+            var codeName = result.GetValue("codeName", null)?.AsString;
+
+            if (codeName == null)
+            {
+                return $"Server returned node is recovering error (code = {code}).";
+            }
+            else
+            {
+                return $"Server returned node is recovering error (code = {code}, codeName = \"{codeName}\").";
+            }
+        }
+        #endregion
+
         // fields
         private readonly BsonDocument _result;
 
@@ -42,7 +60,7 @@ namespace MongoDB.Driver
         /// <param name="connectionId">The connection identifier.</param>
         /// <param name="result">The result.</param>
         public MongoNodeIsRecoveringException(ConnectionId connectionId, BsonDocument result)
-            : base(connectionId, "Server returned node is recovering error.")
+            : base(connectionId, CreateMessage(result))
         {
             _result = Ensure.IsNotNull(result, nameof(result));
         }

--- a/tests/MongoDB.Driver.Core.Tests/MongoNodeIsRecoveringExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoNodeIsRecoveringExceptionTests.cs
@@ -36,12 +36,38 @@ namespace MongoDB.Driver
         [Fact]
         public void constructor_should_initialize_subject()
         {
-            var subject = new MongoNodeIsRecoveringException(_connectionId, _serverResult);
+            var result = new MongoNodeIsRecoveringException(_connectionId, _serverResult);
 
-            subject.ConnectionId.Should().BeSameAs(_connectionId);
-            subject.InnerException.Should().BeNull();
-            subject.Message.Should().Be("Server returned node is recovering error.");
-            subject.Result.Should().Be(_serverResult);
+            result.ConnectionId.Should().BeSameAs(_connectionId);
+            result.InnerException.Should().BeNull();
+            result.Message.Should().Be("Server returned node is recovering error (code = -1).");
+            result.Result.Should().BeSameAs(_serverResult);
+        }
+
+        [Fact]
+        public void constructor_should_initialize_subject_when_result_contains_code()
+        {
+            var serverResult = BsonDocument.Parse("{ ok : 0, code : 1234 }");
+
+            var result = new MongoNodeIsRecoveringException(_connectionId, serverResult);
+
+            result.ConnectionId.Should().BeSameAs(_connectionId);
+            result.InnerException.Should().BeNull();
+            result.Message.Should().Be("Server returned node is recovering error (code = 1234).");
+            result.Result.Should().BeSameAs(serverResult);
+        }
+
+        [Fact]
+        public void constructor_should_initialize_subject_when_result_contains_code_and_codeName()
+        {
+            var serverResult = BsonDocument.Parse("{ ok : 0, code : 1234, codeName : 'some name' }");
+
+            var result = new MongoNodeIsRecoveringException(_connectionId, serverResult);
+
+            result.ConnectionId.Should().BeSameAs(_connectionId);
+            result.InnerException.Should().BeNull();
+            result.Message.Should().Be("Server returned node is recovering error (code = 1234, codeName = \"some name\").");
+            result.Result.Should().BeSameAs(serverResult);
         }
 
 #if NET45


### PR DESCRIPTION
The SDAM spec was recently changed to say that a number of error codes should be considered "node is recovering" errors.

We used to be able to assume that a MongoNodeIsRecoveringException unambiguously meant that a secondary was catching up with the oplog after restarting (the usual definition of "recovering").

We are adding the error code and codeName to the exception message so that applications (and we!) can tell exactly which error code caused a MongoNodeIsRecoveringException to be thrown.

Evergreen patch:

https://evergreen.mongodb.com/version/5aeb1320c9ec4469219a7091