### PR TITLE
CSHARP-2221: Add ReadPreference to TransactionOptions and update JSON driven transaction tests

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Bindings/CoreSession.cs
+++ b/src/MongoDB.Driver.Core/Core/Bindings/CoreSession.cs
@@ -294,9 +294,7 @@ namespace MongoDB.Driver.Core.Bindings
             }
 
             var transactionNumber = AdvanceTransactionNumber();
-            var readConcern = transactionOptions?.ReadConcern ?? _options.DefaultTransactionOptions?.ReadConcern ?? ReadConcern.Default;
-            var writeConcern = transactionOptions?.WriteConcern ?? _options.DefaultTransactionOptions?.WriteConcern ?? new WriteConcern();
-            var effectiveTransactionOptions = new TransactionOptions(readConcern, writeConcern);
+            var effectiveTransactionOptions = GetEffectiveTransactionOptions(transactionOptions);
             var transaction = new CoreTransaction(transactionNumber, effectiveTransactionOptions);
 
             _currentTransaction = transaction;
@@ -344,6 +342,14 @@ namespace MongoDB.Driver.Core.Bindings
             {
                 return await operation.ExecuteAsync(binding, cancellationToken).ConfigureAwait(false);
             }
+        }
+
+        private TransactionOptions GetEffectiveTransactionOptions(TransactionOptions transactionOptions)
+        {
+            var readConcern = transactionOptions?.ReadConcern ?? _options.DefaultTransactionOptions?.ReadConcern ?? ReadConcern.Default;
+            var readPreference = transactionOptions?.ReadPreference ?? _options.DefaultTransactionOptions?.ReadPreference ?? ReadPreference.Primary;
+            var writeConcern = transactionOptions?.WriteConcern ?? _options.DefaultTransactionOptions?.WriteConcern ?? new WriteConcern();
+            return new TransactionOptions(readConcern, readPreference, writeConcern);
         }
 
         private WriteConcern GetTransactionWriteConcern()

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
@@ -191,7 +191,6 @@ namespace MongoDB.Driver.Core.WireProtocol
             {
                 var transaction = _session.CurrentTransaction;
                 extraElements.Add(new BsonElement("txnNumber", transaction.TransactionNumber));
-                extraElements.Add(new BsonElement("stmtId", transaction.StatementId));
                 if (transaction.StatementId == 0)
                 {
                     extraElements.Add(new BsonElement("startTransaction", true));

--- a/src/MongoDB.Driver.Core/TransactionOptions.cs
+++ b/src/MongoDB.Driver.Core/TransactionOptions.cs
@@ -29,6 +29,7 @@ namespace MongoDB.Driver
     {
         // private fields
         private readonly ReadConcern _readConcern;
+        private readonly ReadPreference _readPreference;
         private readonly WriteConcern _writeConcern;
 
         // public constructors
@@ -36,12 +37,15 @@ namespace MongoDB.Driver
         /// Initializes a new instance of the <see cref="TransactionOptions" /> class.
         /// </summary>
         /// <param name="readConcern">The read concern.</param>
+        /// <param name="readPreference">The read preference.</param>
         /// <param name="writeConcern">The write concern.</param>
         public TransactionOptions(
             Optional<ReadConcern> readConcern = default(Optional<ReadConcern>),
+            Optional<ReadPreference> readPreference = default(Optional<ReadPreference>),
             Optional<WriteConcern> writeConcern = default(Optional<WriteConcern>))
         {
             _readConcern = readConcern.WithDefault(null);
+            _readPreference = readPreference.WithDefault(null);
             _writeConcern = writeConcern.WithDefault(null);
         }
 
@@ -53,6 +57,14 @@ namespace MongoDB.Driver
         /// The read concern.
         /// </value>
         public ReadConcern ReadConcern => _readConcern;
+
+        /// <summary>
+        /// Gets the read preference.
+        /// </summary>
+        /// <value>
+        /// The read preference.
+        /// </value>
+        public ReadPreference ReadPreference => _readPreference;
 
         /// <summary>
         /// Gets the write concern.
@@ -67,14 +79,19 @@ namespace MongoDB.Driver
         /// Returns a new TransactionOptions with some values changed.
         /// </summary>
         /// <param name="readConcern">The new read concern.</param>
+        /// <param name="readPreference">The read preference.</param>
         /// <param name="writeConcern">The new write concern.</param>
-        /// <returns>The new TransactionOptions.</returns>
+        /// <returns>
+        /// The new TransactionOptions.
+        /// </returns>
         public TransactionOptions With(
             Optional<ReadConcern> readConcern = default(Optional<ReadConcern>),
+            Optional<ReadPreference> readPreference = default(Optional<ReadPreference>),
             Optional<WriteConcern> writeConcern = default(Optional<WriteConcern>))
         {
             return new TransactionOptions(
                 readConcern: readConcern.WithDefault(_readConcern),
+                readPreference: readPreference.WithDefault(_readPreference),
                 writeConcern: writeConcern.WithDefault(_writeConcern));
         }
     }

--- a/src/MongoDB.Driver/ClientSessionHandle.cs
+++ b/src/MongoDB.Driver/ClientSessionHandle.cs
@@ -130,7 +130,19 @@ namespace MongoDB.Driver
         /// <inheritdoc />
         public void StartTransaction(TransactionOptions transactionOptions = null)
         {
-            _coreSession.StartTransaction(transactionOptions);
+            var effectiveTransactionOptions = GetEffectiveTransactionOptions(transactionOptions);
+            _coreSession.StartTransaction(effectiveTransactionOptions);
+        }
+
+        // private methods
+        private TransactionOptions GetEffectiveTransactionOptions(TransactionOptions transactionOptions)
+        {
+            var defaultTransactionOptions = _options?.DefaultTransactionOptions;
+            var readConcern = transactionOptions?.ReadConcern ?? defaultTransactionOptions?.ReadConcern ?? _client.Settings?.ReadConcern ?? ReadConcern.Default;
+            var readPreference = transactionOptions?.ReadPreference ?? defaultTransactionOptions?.ReadPreference ?? _client.Settings?.ReadPreference ?? ReadPreference.Primary;
+            var writeConcern = transactionOptions?.WriteConcern ?? defaultTransactionOptions?.WriteConcern ?? _client.Settings?.WriteConcern ?? new WriteConcern();
+
+            return new TransactionOptions(readConcern, readPreference, writeConcern);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.TestHelpers/JsonDrivenTests/CommandStartedEventAsserter.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/JsonDrivenTests/CommandStartedEventAsserter.cs
@@ -95,7 +95,6 @@ namespace MongoDB.Driver.Core.TestHelpers.JsonDrivenTests
                     case "autocommit":
                     case "readConcern":
                     case "startTransaction":
-                    case "stmtId":
                     case "txnNumber":
                     case "writeConcern":
                         if (actualCommand.Contains(name))

--- a/tests/MongoDB.Driver.Core.Tests/TransactionOptionsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/TransactionOptionsTests.cs
@@ -100,7 +100,7 @@ namespace MongoDB.Driver
         public void With_with_readConcern_should_return_expected_result(
             [Values(false, true)] bool nullReadConcern)
         {
-            var subject = new TransactionOptions(new ReadConcern(), new WriteConcern());
+            var subject = new TransactionOptions(new ReadConcern(), new ReadPreference(ReadPreferenceMode.Primary), new WriteConcern());
             var readConcern = nullReadConcern ? null : new ReadConcern();
 
             var result = subject.With(readConcern: readConcern);
@@ -113,7 +113,7 @@ namespace MongoDB.Driver
         public void With_with_writeConcern_should_return_expected_result(
             [Values(false, true)] bool nullWriteConcern)
         {
-            var subject = new TransactionOptions(new ReadConcern(), new WriteConcern());
+            var subject = new TransactionOptions(new ReadConcern(), new ReadPreference(ReadPreferenceMode.Primary), new WriteConcern());
             var writeConcern = nullWriteConcern ? null : new WriteConcern();
 
             var result = subject.With(writeConcern: writeConcern);
@@ -127,7 +127,7 @@ namespace MongoDB.Driver
             [Values(false, true)] bool nullReadConcern,
             [Values(false, true)] bool nullWriteConcern)
         {
-            var subject = new TransactionOptions(new ReadConcern(), new WriteConcern());
+            var subject = new TransactionOptions(new ReadConcern(), new ReadPreference(ReadPreferenceMode.Primary), new WriteConcern());
             var readConcern = nullReadConcern ? null : new ReadConcern();
             var writeConcern = nullWriteConcern ? null : new WriteConcern();
 

--- a/tests/MongoDB.Driver.Tests/ClientSessionHandleTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClientSessionHandleTests.cs
@@ -255,7 +255,7 @@ namespace MongoDB.Driver.Tests
 
             subject.StartTransaction(transactionOptions);
 
-            Mock.Get(subject.WrappedCoreSession).Verify(m => m.StartTransaction(transactionOptions), Times.Once);
+            Mock.Get(subject.WrappedCoreSession).Verify(m => m.StartTransaction(It.IsAny<TransactionOptions>()), Times.Once);
         }
 
         // private methods

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenStartTransactionTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenStartTransactionTest.cs
@@ -23,7 +23,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
     public sealed class JsonDrivenStartTransactionTest : JsonDrivenClientTest
     {
         // private fields
-        private TransactionOptions _options = new TransactionOptions();
+        private TransactionOptions _options = null;
 
         // public constructors
         public JsonDrivenStartTransactionTest(IMongoClient client, Dictionary<string, IClientSessionHandle> sessionMap)
@@ -59,17 +59,25 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
         // private methods
         private void SetOptions(BsonDocument document)
         {
-            JsonDrivenHelper.EnsureAllFieldsAreValid(document, "readConcern", "writeConcern");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(document, "readConcern", "readPreference", "writeConcern");
 
+            var options = new TransactionOptions();
             if (document.Contains("readConcern"))
             {
-                _options = _options.With(readConcern: ReadConcern.FromBsonDocument(document["readConcern"].AsBsonDocument));
+                options = options.With(readConcern: ReadConcern.FromBsonDocument(document["readConcern"].AsBsonDocument));
+            }
+
+            if (document.Contains("readPreference"))
+            {
+                options = options.With(readPreference: ReadPreference.FromBsonDocument(document["readPreference"].AsBsonDocument));
             }
 
             if (document.Contains("writeConcern"))
             {
-                _options = _options.With(writeConcern: WriteConcern.FromBsonDocument(document["writeConcern"].AsBsonDocument));
+                options = options.With(writeConcern: WriteConcern.FromBsonDocument(document["writeConcern"].AsBsonDocument));
             }
+
+            _options = options;
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
+++ b/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
@@ -215,7 +215,7 @@
     <Compile Include="Specifications\retryable-writes\IRetryableWriteTest.cs" />
     <Compile Include="Specifications\retryable-writes\TestRunner.cs" />
     <Compile Include="Specifications\retryable-writes\UpdateOneTest.cs" />
-    <Compile Include="Specifications\transactions\TestRunner.cs" />
+    <Compile Include="Specifications\transactions\TransactionTestRunner.cs" />
     <Compile Include="UpdateDefinitionBuilderTests.cs" />
     <Compile Include="FilterDefinitionBuilderTests.cs" />
     <Compile Include="IAggregateFluentExtensionsTests.cs" />

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/README.rst
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/README.rst
@@ -22,8 +22,11 @@ Test Format
 
 Each YAML file has the following keys:
 
+- ``database_name`` and ``collection_name``: The database and collection to use
+  for testing.
+
 - ``data``: The data that should exist in the collection under test before each
-  test run. (TODO: not used yet.)
+  test run.
 
 - ``tests``: An array of tests that are to be run independently of each other.
   Each test will have some or all of the following fields:
@@ -73,6 +76,8 @@ For each YAML file, for each element in ``tests``:
    transactions from previous test failures. The command will fail with message
    "operation was interrupted", because it kills its own implicit session. Catch
    the exception and continue.
+#. Create a collection object from the MongoClient, using the ``database_name``
+   and ``collection_name`` fields of the YAML file.
 #. Drop the test collection, using writeConcern "majority".
 #. Execute the "create" command to recreate the collection, using writeConcern
    "majority". (Creating the collection inside a transaction is prohibited, so
@@ -121,7 +126,9 @@ For each YAML file, for each element in ``tests``:
 #. For each element in ``outcome``:
 
    - If ``name`` is "collection", verify that the test collection contains
-     exactly the documents in the ``data`` array.
+     exactly the documents in the ``data`` array. Ensure this find uses
+     Primary read preference even when the MongoClient is configured with
+     another read preference.
 
 TODO:
 
@@ -131,6 +138,9 @@ TODO:
 
 Command-Started Events
 ``````````````````````
+
+The event listener used for these tests MUST ignore the security commands
+listed in the Command Monitoring Spec.
 
 Logical Session Id
 ~~~~~~~~~~~~~~~~~~
@@ -144,7 +154,7 @@ Null Values
 ~~~~~~~~~~~
 
 Some command-started events in ``expectations`` include ``null`` values for
-fields such as ``txnNumber``, ``autocommit``, ``writeConcern``, and ``stmtId``.
+fields such as ``txnNumber``, ``autocommit``, and ``writeConcern``.
 Tests MUST assert that the actual command **omits** any field that has a
 ``null`` value in the expected command.
 

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/abort.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/abort.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [],
   "tests": [
     {
@@ -69,7 +71,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -86,7 +87,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -112,7 +112,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -129,7 +128,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -183,7 +181,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -200,7 +197,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -269,7 +265,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -286,7 +281,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -375,7 +369,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -392,7 +385,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -471,7 +463,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -495,7 +486,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -519,7 +509,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -536,13 +525,51 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 3,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "abort does not apply writeConcern",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "writeConcern": {
+                "w": 10
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
           }
         }
       ],

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/abort.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/abort.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: []
 
 tests:
@@ -34,7 +37,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -42,19 +45,17 @@ tests:
             lsid: session0
             txnNumber:
                $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               "$numberLong": "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -62,7 +63,7 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -71,19 +72,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -113,7 +112,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -121,19 +120,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -169,7 +166,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -177,19 +174,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -240,7 +235,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -248,19 +243,17 @@ tests:
             lsid: session0
             txnNumber:
                $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -304,7 +297,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -312,15 +305,14 @@ tests:
             lsid: session0
             txnNumber:
                $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -328,15 +320,14 @@ tests:
             lsid: session0
             txnNumber:
                $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -344,25 +335,48 @@ tests:
             lsid: session0
             txnNumber:
                $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 3
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: abortTransaction
           database_name: admin
 
+
+    outcome:
+      collection:
+        data: []
+
+  - description: abort does not apply writeConcern
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+          options:
+            writeConcern:
+              w: 10
+      - name: insertOne
+        arguments:
+          document:
+            _id: 1
+          session: session0
+        result:
+          insertedId: 1
+      - name: abortTransaction
+        arguments:
+          session: session0
+        # No CannotSatisfyWriteConcern error.
 
     outcome:
       collection:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/auto-start.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/auto-start.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [],
   "tests": [
     {
@@ -74,7 +76,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -91,7 +92,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -117,7 +117,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -140,7 +139,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -157,7 +155,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -256,7 +253,6 @@
               "txnNumber": {
                 "$numberLong": "3"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -273,7 +269,6 @@
               "txnNumber": {
                 "$numberLong": "3"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -345,7 +340,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -362,7 +356,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -443,7 +436,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -460,7 +452,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -486,7 +477,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -503,7 +493,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -578,7 +567,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -595,7 +583,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -682,7 +669,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -700,7 +686,6 @@
               },
               "lsid": "session1",
               "txnNumber": null,
-              "stmtId": null,
               "startTransaction": null,
               "autocommit": null
             },
@@ -716,7 +701,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -737,7 +721,6 @@
               },
               "lsid": "session1",
               "txnNumber": null,
-              "stmtId": null,
               "startTransaction": null,
               "autocommit": null
             },

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/auto-start.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/auto-start.yml
@@ -1,4 +1,8 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: []
+
 tests:
   - description: commit
 
@@ -38,7 +42,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -46,19 +50,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -66,7 +68,7 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
@@ -75,34 +77,31 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 3
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 2
             startTransaction:
             autocommit: false
             writeConcern:
@@ -152,7 +151,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -160,19 +159,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "3"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "3"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -212,7 +209,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -220,19 +217,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -275,7 +270,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -283,19 +278,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -303,7 +296,7 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
@@ -312,19 +305,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -365,7 +356,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -373,19 +364,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -432,7 +421,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -440,31 +429,28 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            find: test
+            find: *collection_name
             filter:
               _id: 1
             lsid: session1
             txnNumber:
-            stmtId:
             startTransaction:
             autocommit:
           command_name: find
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -472,18 +458,17 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            find: test
+            find: *collection_name
             filter:
               _id: 1
             readConcern:
               afterClusterTime: 42
             lsid: session1
             txnNumber:
-            stmtId:
             startTransaction:
             autocommit:
           command_name: find
-          database_name: transaction-tests
+          database_name: *database_name
 
     outcome:
       collection:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/bulk.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/bulk.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [],
   "tests": [
     {
@@ -220,7 +222,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -246,7 +247,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -269,7 +269,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -313,7 +312,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 3,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -348,7 +346,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 5,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -388,7 +385,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 10,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -428,7 +424,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 12,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -462,7 +457,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 15,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -479,7 +473,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 16,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/bulk.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/bulk.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: []
 
 tests:
@@ -7,7 +10,6 @@ tests:
       - name: startTransaction
         arguments:
           session: session0
-      # A couple of commands to check that bulkWrite uses stmtId 2.
       - name: insertOne
         arguments:
           document:
@@ -28,7 +30,6 @@ tests:
             - name: insertOne
               arguments:
                 document: {_id: 1}
-            # A series of updates allows the driver to skip stmtIds.
             - name: updateOne
               arguments:
                 filter: {_id: 1}
@@ -91,7 +92,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -99,15 +100,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            delete: test
+            delete: *collection_name
             deletes:
               - q: {_id: 1}
                 limit: 1
@@ -115,31 +115,29 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: delete
-          database_name: transaction-tests
+          database_name: *database_name
       # Commands in the bulkWrite.
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {_id: 1}
                 u: {$set: {x: 1}}
@@ -153,15 +151,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 3
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 3
               - _id: 4
@@ -172,15 +169,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 5
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {_id: 1}
                 u: {y: 1}
@@ -194,15 +190,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 10
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            delete: test
+            delete: *collection_name
             deletes:
               - q: {_id: 3}
                 limit: 1
@@ -214,15 +209,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 12
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: delete
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {_id: {$gte: 2}}
                 u: {$set: {z: 1}}
@@ -232,19 +226,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 15
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 16
             startTransaction:
             autocommit: false
             writeConcern:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/causal-consistency.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/causal-consistency.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [
     {
       "_id": 1,
@@ -85,7 +87,6 @@
               "lsid": "session0",
               "readConcern": null,
               "txnNumber": null,
-              "stmtId": null,
               "startTransaction": null,
               "autocommit": null,
               "writeConcern": null
@@ -120,7 +121,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -137,7 +137,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -225,7 +224,6 @@
               "readConcern": null,
               "lsid": "session0",
               "txnNumber": null,
-              "stmtId": null,
               "autocommit": null,
               "writeConcern": null
             },
@@ -257,7 +255,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -274,7 +271,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/causal-consistency.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/causal-consistency.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data:
   - _id: 1
     count: 0
@@ -33,7 +36,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {_id: 1}
                 u: {$inc: {count: 1}}
@@ -43,15 +46,14 @@ tests:
             lsid: session0
             readConcern:
             txnNumber:
-            stmtId:
             startTransaction:
             autocommit:
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {_id: 1}
                 u: {$inc: {count: 1}}
@@ -63,19 +65,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -124,21 +124,20 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
             readConcern:
             lsid: session0
             txnNumber:
-            stmtId:
             autocommit:
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {_id: 1}
                 u: {$inc: {count: 1}}
@@ -150,19 +149,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/commit.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/commit.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [],
   "tests": [
     {
@@ -69,7 +71,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -86,7 +87,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -112,7 +112,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -129,7 +128,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -205,7 +203,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -222,13 +219,58 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "write concern error on commit",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "writeConcern": {
+                "w": 10
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          },
+          "result": {
+            "errorCodeName": "CannotSatisfyWriteConcern"
           }
         }
       ],

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/commit.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/commit.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: []
 tests:
   - description: commit
@@ -34,7 +37,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -42,19 +45,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -62,7 +63,7 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
@@ -71,19 +72,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -122,7 +121,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -130,24 +129,57 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: commitTransaction
           database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1
+
+  - description: write concern error on commit
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+          options:
+            writeConcern:
+              w: 10
+      - name: insertOne
+        arguments:
+          document:
+            _id: 1
+          session: session0
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        arguments:
+          session: session0
+        result:
+          # {
+          #   'ok': 1.0,
+          #   'writeConcernError': {
+          #     'code': 100,
+          #     'codeName': 'CannotSatisfyWriteConcern',
+          #     'errmsg': 'Not enough data-bearing nodes'
+          #   }
+          # }
+          errorCodeName: CannotSatisfyWriteConcern
 
     outcome:
       collection:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/delete.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/delete.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [
     {
       "_id": 1
@@ -90,7 +92,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -118,7 +119,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -144,7 +144,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -161,7 +160,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 3,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -253,7 +251,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -281,7 +278,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -298,7 +294,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": {

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/delete.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/delete.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data:
   - _id: 1
   - _id: 2
@@ -40,7 +43,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            delete: test
+            delete: *collection_name
             deletes:
               - q: {_id: 1}
                 limit: 1
@@ -49,15 +52,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: delete
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            delete: test
+            delete: *collection_name
             deletes:
               - q: {_id: {$lte: 3}}
                 limit: 0
@@ -65,15 +67,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: delete
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            delete: test
+            delete: *collection_name
             deletes:
               - q: {_id: 4}
                 limit: 1
@@ -81,19 +82,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: delete
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 3
             startTransaction:
             autocommit: false
             writeConcern:
@@ -138,7 +137,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            delete: test
+            delete: *collection_name
             deletes:
               - q: {_id: 1}
                 limit: 1
@@ -147,15 +146,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: delete
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            delete: test
+            delete: *collection_name
             deletes:
               - q: {_id: {$lte: 3}}
                 limit: 0
@@ -163,19 +161,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: delete
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
             writeConcern:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/errors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/errors.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [],
   "tests": [
     {

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/errors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/errors.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: []
 tests:
   - description: start insert start

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndDelete.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndDelete.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [
     {
       "_id": 1
@@ -62,7 +64,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": null,
@@ -84,7 +85,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -102,7 +102,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -175,7 +174,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": null,
@@ -193,7 +191,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndDelete.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndDelete.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data:
   - _id: 1
   - _id: 2
@@ -27,41 +30,38 @@ tests:
     expectations:
       - command_started_event:
           command:
-            findAndModify: test
+            findAndModify: *collection_name
             query: {_id: 3}
             remove: True
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
             writeConcern:
           command_name: findAndModify
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            findAndModify: test
+            findAndModify: *collection_name
             query: {_id: 4}
             remove: True
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
             writeConcern:
           command_name: findAndModify
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
             readConcern:
@@ -98,26 +98,24 @@ tests:
     expectations:
       - command_started_event:
           command:
-            findAndModify: test
+            findAndModify: *collection_name
             query: {_id: 3}
             remove: True
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
             writeConcern:
           command_name: findAndModify
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndReplace.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndReplace.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [
     {
       "_id": 1
@@ -77,7 +79,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": null,
@@ -103,7 +104,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -121,7 +121,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -209,7 +208,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": null,
@@ -227,7 +225,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndReplace.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndReplace.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data:
   - _id: 1
   - _id: 2
@@ -32,23 +35,22 @@ tests:
     expectations:
       - command_started_event:
           command:
-            findAndModify: test
+            findAndModify: *collection_name
             query: {_id: 3}
             update: {x: 1}
             new: false
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
             writeConcern:
           command_name: findAndModify
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            findAndModify: test
+            findAndModify: *collection_name
             query: {_id: 4}
             update: {x: 1}
             new: true
@@ -56,20 +58,18 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
             writeConcern:
           command_name: findAndModify
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
             readConcern:
@@ -110,27 +110,25 @@ tests:
     expectations:
       - command_started_event:
           command:
-            findAndModify: test
+            findAndModify: *collection_name
             query: {_id: 3}
             update: {x: 1}
             new: false
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
             writeConcern:
           command_name: findAndModify
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndUpdate.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndUpdate.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [
     {
       "_id": 1
@@ -145,7 +147,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": null,
@@ -173,7 +174,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -191,7 +191,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -218,7 +217,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -238,7 +236,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -265,7 +262,6 @@
               "txnNumber": {
                 "$numberLong": "3"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -285,7 +281,6 @@
               "txnNumber": {
                 "$numberLong": "3"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -377,7 +372,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": null,
@@ -395,7 +389,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndUpdate.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/findOneAndUpdate.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data:
   - _id: 1
   - _id: 2
@@ -64,23 +67,22 @@ tests:
     expectations:
       - command_started_event:
           command:
-            findAndModify: test
+            findAndModify: *collection_name
             query: {_id: 3}
             update: {$inc: {x: 1}}
             new: false
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
             writeConcern:
           command_name: findAndModify
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            findAndModify: test
+            findAndModify: *collection_name
             query: {_id: 4}
             update: {$inc: {x: 1}}
             new: true
@@ -88,20 +90,18 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
             writeConcern:
           command_name: findAndModify
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
             readConcern:
@@ -110,28 +110,26 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            findAndModify: test
+            findAndModify: *collection_name
             query: {_id: 3}
             update: {$inc: {x: 1}}
             new: false
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
               afterClusterTime: 42
             writeConcern:
           command_name: findAndModify
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -140,28 +138,26 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            findAndModify: test
+            findAndModify: *collection_name
             query: {_id: 3}
             update: {$inc: {x: 1}}
             new: false
             lsid: session0
             txnNumber:
               $numberLong: "3"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
               afterClusterTime: 42
             writeConcern:
           command_name: findAndModify
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "3"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -203,7 +199,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            findAndModify: test
+            findAndModify: *collection_name
             query: {_id: 3}
             update:
               $inc: {x: 1}
@@ -211,20 +207,18 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
             writeConcern:
           command_name: findAndModify
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/insert.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/insert.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [],
   "tests": [
     {
@@ -101,7 +103,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -127,7 +128,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -150,7 +150,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 3,
               "autocommit": false,
               "writeConcern": null
             },
@@ -166,7 +165,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 4,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -192,7 +190,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -209,7 +206,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -316,7 +312,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -342,7 +337,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -359,7 +353,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 3,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": {

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/insert.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/insert.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: []
 
 tests:
@@ -49,7 +52,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -57,15 +60,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
               - _id: 3
@@ -73,33 +75,30 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 4
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 3 # Skip statement id 2.
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 4
             startTransaction:
             autocommit: false
             writeConcern:
@@ -107,7 +106,7 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 5
             ordered: true
@@ -116,19 +115,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -178,7 +175,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -186,15 +183,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
               - _id: 3
@@ -202,19 +198,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 3
             startTransaction:
             autocommit: false
             writeConcern:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/isolation.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/isolation.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [],
   "tests": [
     {

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/isolation.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/isolation.yml
@@ -1,5 +1,8 @@
 # Test snapshot isolation.
 # This test doesn't check contents of command-started events.
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: []
 
 tests:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/read-pref.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/read-pref.json
@@ -1,8 +1,10 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [],
   "tests": [
     {
-      "description": "primary",
+      "description": "default readPreference",
       "operations": [
         {
           "name": "startTransaction",
@@ -11,25 +13,41 @@
           }
         },
         {
-          "name": "insertOne",
+          "name": "insertMany",
           "arguments": {
-            "document": {
-              "_id": 1
-            },
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              },
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ],
             "session": "session0"
           },
           "result": {
-            "insertedId": 1
+            "insertedIds": {
+              "0": 1,
+              "1": 2,
+              "2": 3,
+              "3": 4
+            }
           }
         },
         {
           "name": "count",
           "arguments": {
+            "readPreference": {
+              "mode": "Secondary"
+            },
             "filter": {
               "_id": 1
-            },
-            "readPreference": {
-              "mode": "primary"
             },
             "session": "session0"
           },
@@ -38,17 +56,33 @@
         {
           "name": "find",
           "arguments": {
+            "readPreference": {
+              "mode": "Secondary"
+            },
+            "batchSize": 3,
             "session": "session0"
           },
           "result": [
             {
               "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
             }
           ]
         },
         {
           "name": "aggregate",
           "arguments": {
+            "readPreference": {
+              "mode": "Secondary"
+            },
             "pipeline": [
               {
                 "$project": {
@@ -62,6 +96,15 @@
           "result": [
             {
               "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
             }
           ]
         },
@@ -77,18 +120,477 @@
           "data": [
             {
               "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
             }
           ]
         }
       }
     },
     {
-      "description": "write and read",
+      "description": "primary readPreference",
       "operations": [
         {
           "name": "startTransaction",
           "arguments": {
+            "session": "session0",
+            "options": {
+              "readPreference": {
+                "mode": "Primary"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              },
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ],
             "session": "session0"
+          },
+          "result": {
+            "insertedIds": {
+              "0": 1,
+              "1": 2,
+              "2": 3,
+              "3": 4
+            }
+          }
+        },
+        {
+          "name": "count",
+          "arguments": {
+            "readPreference": {
+              "mode": "Secondary"
+            },
+            "filter": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "readPreference": {
+              "mode": "Secondary"
+            },
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        },
+        {
+          "name": "aggregate",
+          "arguments": {
+            "readPreference": {
+              "mode": "Secondary"
+            },
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ],
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "secondary readPreference",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readPreference": {
+                "mode": "Secondary"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              },
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ],
+            "session": "session0"
+          },
+          "result": {
+            "insertedIds": {
+              "0": 1,
+              "1": 2,
+              "2": 3,
+              "3": 4
+            }
+          }
+        },
+        {
+          "name": "count",
+          "arguments": {
+            "readPreference": {
+              "mode": "Primary"
+            },
+            "filter": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "readPreference": {
+              "mode": "Primary"
+            },
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "aggregate",
+          "arguments": {
+            "readPreference": {
+              "mode": "Primary"
+            },
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ],
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "primaryPreferred readPreference",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readPreference": {
+                "mode": "PrimaryPreferred"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              },
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ],
+            "session": "session0"
+          },
+          "result": {
+            "insertedIds": {
+              "0": 1,
+              "1": 2,
+              "2": 3,
+              "3": 4
+            }
+          }
+        },
+        {
+          "name": "count",
+          "arguments": {
+            "readPreference": {
+              "mode": "Primary"
+            },
+            "filter": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "readPreference": {
+              "mode": "Primary"
+            },
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "aggregate",
+          "arguments": {
+            "readPreference": {
+              "mode": "Primary"
+            },
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ],
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "nearest readPreference",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readPreference": {
+                "mode": "Nearest"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              },
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ],
+            "session": "session0"
+          },
+          "result": {
+            "insertedIds": {
+              "0": 1,
+              "1": 2,
+              "2": 3,
+              "3": 4
+            }
+          }
+        },
+        {
+          "name": "count",
+          "arguments": {
+            "readPreference": {
+              "mode": "Primary"
+            },
+            "filter": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "readPreference": {
+              "mode": "Primary"
+            },
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "aggregate",
+          "arguments": {
+            "readPreference": {
+              "mode": "Primary"
+            },
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ],
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "secondary write only",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readPreference": {
+                "mode": "Secondary"
+              }
+            }
           }
         },
         {
@@ -104,49 +606,6 @@
           }
         },
         {
-          "name": "count",
-          "arguments": {
-            "readPreference": {
-              "mode": "secondary"
-            },
-            "session": "session0"
-          },
-          "result": {
-            "errorContains": "read preference in a transaction must be primary"
-          }
-        },
-        {
-          "name": "find",
-          "arguments": {
-            "readPreference": {
-              "mode": "secondary"
-            },
-            "session": "session0"
-          },
-          "result": {
-            "errorContains": "read preference in a transaction must be primary"
-          }
-        },
-        {
-          "name": "aggregate",
-          "arguments": {
-            "pipeline": [
-              {
-                "$project": {
-                  "_id": 1
-                }
-              }
-            ],
-            "readPreference": {
-              "mode": "secondary"
-            },
-            "session": "session0"
-          },
-          "result": {
-            "errorContains": "read preference in a transaction must be primary"
-          }
-        },
-        {
           "name": "commitTransaction",
           "arguments": {
             "session": "session0"
@@ -160,146 +619,6 @@
               "_id": 1
             }
           ]
-        }
-      }
-    },
-    {
-      "description": "non-primary readPreference",
-      "operations": [
-        {
-          "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
-        },
-        {
-          "name": "count",
-          "arguments": {
-            "readPreference": {
-              "mode": "secondary"
-            },
-            "session": "session0"
-          },
-          "result": {
-            "errorContains": "read preference in a transaction must be primary"
-          }
-        },
-        {
-          "name": "find",
-          "arguments": {
-            "readPreference": {
-              "mode": "secondary"
-            },
-            "session": "session0"
-          },
-          "result": {
-            "errorContains": "read preference in a transaction must be primary"
-          }
-        },
-        {
-          "name": "aggregate",
-          "arguments": {
-            "pipeline": [
-              {
-                "$project": {
-                  "_id": 1
-                }
-              }
-            ],
-            "readPreference": {
-              "mode": "secondary"
-            },
-            "session": "session0"
-          },
-          "result": {
-            "errorContains": "read preference in a transaction must be primary"
-          }
-        },
-        {
-          "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
-        }
-      ],
-      "outcome": {
-        "collection": {
-          "data": []
-        }
-      }
-    },
-    {
-      "description": "conflict",
-      "operations": [
-        {
-          "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
-        },
-        {
-          "name": "count",
-          "arguments": {
-            "readPreference": {
-              "mode": "primary"
-            },
-            "session": "session0"
-          },
-          "result": 0
-        },
-        {
-          "name": "count",
-          "arguments": {
-            "readPreference": {
-              "mode": "secondary"
-            },
-            "session": "session0"
-          },
-          "result": {
-            "errorContains": "read preference in a transaction must be primary"
-          }
-        },
-        {
-          "name": "find",
-          "arguments": {
-            "session": "session0",
-            "readPreference": {
-              "mode": "secondary"
-            }
-          },
-          "result": {
-            "errorContains": "read preference in a transaction must be primary"
-          }
-        },
-        {
-          "name": "aggregate",
-          "arguments": {
-            "pipeline": [
-              {
-                "$project": {
-                  "_id": 1
-                }
-              }
-            ],
-            "readPreference": {
-              "mode": "secondary"
-            },
-            "session": "session0"
-          },
-          "result": {
-            "errorContains": "read preference in a transaction must be primary"
-          }
-        },
-        {
-          "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
-        }
-      ],
-      "outcome": {
-        "collection": {
-          "data": []
         }
       }
     }

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/read-pref.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/read-pref.yml
@@ -1,56 +1,287 @@
 # This test doesn't check contents of command-started events.
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: []
+
 tests:
-  - description: primary
+  - description: default readPreference
 
     operations:
       - name: startTransaction
         arguments:
           session: session0
-      - name: insertOne
+      - name: insertMany
         arguments:
-          document:
-            _id: 1
+          documents: &insertedDocs
+            - _id: 1
+            - _id: 2
+            - _id: 3
+            - _id: 4
           session: session0
         result:
-          insertedId: 1
+          insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
       - name: count
         arguments:
+          # The driver overrides the operation's read pref with the
+          # transaction's so count runs with Primary and succeeds.
+          readPreference:
+            mode: Secondary
           filter:
             _id: 1
-          readPreference:
-            mode: primary
           session: session0
         result: 1
       - name: find
         arguments:
+          readPreference:
+            mode: Secondary
+          batchSize: 3
           session: session0
-        result:
-          - _id: 1
+        result: *insertedDocs
       - name: aggregate
         arguments:
+          readPreference:
+            mode: Secondary
+          pipeline:
+            - $project:
+                _id: 1
+          batchSize: 3
+          session: session0
+        result: *insertedDocs
+      - name: commitTransaction
+        arguments:
+          session: session0
+
+    outcome:
+      collection:
+        data: *insertedDocs
+
+  - description: primary readPreference
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+          options:
+            readPreference:
+              mode: Primary
+      - name: insertMany
+        arguments:
+          documents: &insertedDocs
+            - _id: 1
+            - _id: 2
+            - _id: 3
+            - _id: 4
+          session: session0
+        result:
+          insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
+      - name: count
+        arguments:
+          readPreference:
+            mode: Secondary
+          filter:
+            _id: 1
+          session: session0
+        result: 1
+      - name: find
+        arguments:
+          readPreference:
+            mode: Secondary
+          batchSize: 3
+          session: session0
+        result: *insertedDocs
+      - name: aggregate
+        arguments:
+          readPreference:
+            mode: Secondary
+          pipeline:
+            - $project:
+                _id: 1
+          batchSize: 3
+          session: session0
+        result: *insertedDocs
+      - name: commitTransaction
+        arguments:
+          session: session0
+
+    outcome:
+      collection:
+        data: *insertedDocs
+
+  - description: secondary readPreference
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+          options:
+            readPreference:
+              mode: Secondary
+      - name: insertMany
+        arguments:
+          documents: &insertedDocs
+            - _id: 1
+            - _id: 2
+            - _id: 3
+            - _id: 4
+          session: session0
+        result:
+          insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
+      - name: count
+        arguments:
+          readPreference:
+            mode: Primary
+          filter:
+            _id: 1
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+      - name: find
+        arguments:
+          readPreference:
+            mode: Primary
+          batchSize: 3
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+      - name: aggregate
+        arguments:
+          readPreference:
+            mode: Primary
           pipeline:
             - $project:
                 _id: 1
           batchSize: 3
           session: session0
         result:
-          - _id: 1
-      - name: commitTransaction
+          errorContains: read preference in a transaction must be primary
+      - name: abortTransaction
         arguments:
           session: session0
 
     outcome:
       collection:
-        data:
-          - _id: 1
+        data: []
 
-  - description: write and read
+  - description: primaryPreferred readPreference
 
     operations:
       - name: startTransaction
         arguments:
           session: session0
+          options:
+            readPreference:
+              mode: PrimaryPreferred
+      - name: insertMany
+        arguments:
+          documents: &insertedDocs
+            - _id: 1
+            - _id: 2
+            - _id: 3
+            - _id: 4
+          session: session0
+        result:
+          insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
+      - name: count
+        arguments:
+          readPreference:
+            mode: Primary
+          filter:
+            _id: 1
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+      - name: find
+        arguments:
+          readPreference:
+            mode: Primary
+          batchSize: 3
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+      - name: aggregate
+        arguments:
+          readPreference:
+            mode: Primary
+          pipeline:
+            - $project:
+                _id: 1
+          batchSize: 3
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+      - name: abortTransaction
+        arguments:
+          session: session0
+
+    outcome:
+      collection:
+        data: []
+
+  - description: nearest readPreference
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+          options:
+            readPreference:
+              mode: Nearest
+      - name: insertMany
+        arguments:
+          documents: &insertedDocs
+            - _id: 1
+            - _id: 2
+            - _id: 3
+            - _id: 4
+          session: session0
+        result:
+          insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
+      - name: count
+        arguments:
+          readPreference:
+            mode: Primary
+          filter:
+            _id: 1
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+      - name: find
+        arguments:
+          readPreference:
+            mode: Primary
+          batchSize: 3
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+      - name: aggregate
+        arguments:
+          readPreference:
+            mode: Primary
+          pipeline:
+            - $project:
+                _id: 1
+          batchSize: 3
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+      - name: abortTransaction
+        arguments:
+          session: session0
+
+    outcome:
+      collection:
+        data: []
+
+  - description: secondary write only
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+          options:
+            readPreference:
+              mode: Secondary
       - name: insertOne
         arguments:
           document:
@@ -58,31 +289,6 @@ tests:
           session: session0
         result:
           insertedId: 1
-      - name: count
-        arguments:
-          readPreference:
-            mode: secondary
-          session: session0
-        result:
-          # Client-side error.
-          errorContains: read preference in a transaction must be primary
-      - name: find
-        arguments:
-          readPreference:
-            mode: secondary
-          session: session0
-        result:
-          errorContains: read preference in a transaction must be primary
-      - name: aggregate
-        arguments:
-          pipeline:
-            - $project:
-                _id: 1
-          readPreference:
-            mode: secondary
-          session: session0
-        result:
-          errorContains: read preference in a transaction must be primary
       - name: commitTransaction
         arguments:
           session: session0
@@ -91,87 +297,3 @@ tests:
       collection:
         data:
           - _id: 1
-
-  - description: non-primary readPreference 
-
-    operations:
-      - name: startTransaction
-        arguments:
-          session: session0
-      - name: count
-        arguments:
-          readPreference:
-            mode: secondary
-          session: session0
-        result:
-          # Client-side error.
-          errorContains: read preference in a transaction must be primary
-      - name: find
-        arguments:
-          readPreference:
-            mode: secondary
-          session: session0
-        result:
-          errorContains: read preference in a transaction must be primary
-      - name: aggregate
-        arguments:
-          pipeline:
-            - $project:
-                _id: 1
-          readPreference:
-            mode: secondary
-          session: session0
-        result:
-          errorContains: read preference in a transaction must be primary
-      - name: commitTransaction
-        arguments:
-          session: session0
-
-    outcome:
-      collection:
-        data: []
-
-  - description: conflict
-
-    operations:
-      - name: startTransaction
-        arguments:
-          session: session0
-      - name: count
-        arguments:
-          readPreference:
-            mode: primary
-          session: session0
-        result: 0
-      - name: count
-        arguments:
-          readPreference:
-            mode: secondary
-          session: session0
-        result:
-          # Client-side error.
-          errorContains: read preference in a transaction must be primary
-      - name: find
-        arguments:
-          session: session0
-          readPreference:
-            mode: secondary
-        result:
-          errorContains: read preference in a transaction must be primary
-      - name: aggregate
-        arguments:
-          pipeline:
-            - $project:
-                _id: 1
-          readPreference:
-            mode: secondary
-          session: session0
-        result:
-          errorContains: read preference in a transaction must be primary
-      - name: commitTransaction
-        arguments:
-          session: session0
-
-    outcome:
-      collection:
-        data: []

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/reads.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/reads.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [
     {
       "_id": 1
@@ -63,7 +65,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -83,7 +84,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -100,7 +100,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -198,7 +197,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false
             },
@@ -218,7 +216,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false
             },
@@ -235,7 +232,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false
             },
@@ -255,7 +251,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 3,
               "startTransaction": null,
               "autocommit": false
             },
@@ -271,7 +266,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 4,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -392,7 +386,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false
             },
@@ -412,7 +405,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false
             },
@@ -438,7 +430,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false
             },
@@ -458,7 +449,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 3,
               "startTransaction": null,
               "autocommit": false
             },
@@ -474,7 +464,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 4,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -543,7 +532,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -561,7 +549,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/reads.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/reads.yml
@@ -1,5 +1,6 @@
-# Test all read operations' txnNumbers and stmtIds.
-# Aggregate not yet supported in transactions.
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: &data
   - {_id: 1}
   - {_id: 2}
@@ -31,40 +32,37 @@ tests:
     expectations:
       - command_started_event:
           command:
-            count: test
+            count: *collection_name
             query:
               _id: 1
             readConcern:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: count
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            count: test
+            count: *collection_name
             query:
               _id: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: count
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
             writeConcern:
@@ -92,65 +90,60 @@ tests:
     expectations:
       - command_started_event:
           command:
-            find: test
+            find: *collection_name
             batchSize: 3
             readConcern:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
           command_name: find
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             getMore:
               # 42 is a fake placeholder value for the cursorId.
               $numberLong: '42'
-            collection: test
+            collection: *collection_name
             batchSize: 3
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
           command_name: getMore
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            find: test
+            find: *collection_name
             batchSize: 3
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
           command_name: find
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             getMore:
               $numberLong: '42'
-            collection: test
+            collection: *collection_name
             batchSize: 3
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 3
             startTransaction:
             autocommit: false
           command_name: getMore
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 4
             startTransaction:
             autocommit: false
             writeConcern:
@@ -178,7 +171,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            aggregate: test
+            aggregate: *collection_name
             pipeline:
               - $project:
                   _id: 1
@@ -188,29 +181,27 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
           command_name: aggregate
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             getMore:
               # 42 is a fake placeholder value for the cursorId.
               $numberLong: '42'
-            collection: test
+            collection: *collection_name
             batchSize: 3
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
           command_name: getMore
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            aggregate: test
+            aggregate: *collection_name
             pipeline:
               - $project:
                   _id: 1
@@ -219,32 +210,29 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
           command_name: aggregate
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             getMore:
               $numberLong: '42'
-            collection: test
+            collection: *collection_name
             batchSize: 3
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 3
             startTransaction:
             autocommit: false
           command_name: getMore
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 4
             startTransaction:
             autocommit: false
             writeConcern:
@@ -267,18 +255,17 @@ tests:
     expectations:
       - command_started_event:
           command:
-            distinct: test
+            distinct: *collection_name
             key: _id
             lsid: session0
             readConcern:
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: distinct
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
@@ -286,7 +273,6 @@ tests:
             readConcern:
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-writes.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-writes.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [],
   "tests": [
     {
@@ -104,7 +106,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -121,7 +122,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -145,7 +145,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": null,
               "startTransaction": null,
               "autocommit": null,
               "writeConcern": null
@@ -171,7 +170,6 @@
               "txnNumber": {
                 "$numberLong": "3"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -188,7 +186,6 @@
               "txnNumber": {
                 "$numberLong": "3"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -215,7 +212,6 @@
               "txnNumber": {
                 "$numberLong": "4"
               },
-              "stmtId": null,
               "startTransaction": null,
               "autocommit": null,
               "writeConcern": null

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-writes.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-writes.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: []
 
 tests:
@@ -55,7 +58,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -63,19 +66,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -83,7 +84,7 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
@@ -91,15 +92,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId:
             startTransaction:
             autocommit:
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 3
             ordered: true
@@ -108,19 +108,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "3"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "3"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -128,7 +126,7 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 4
               - _id: 5
@@ -137,12 +135,11 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "4"
-            stmtId:
             startTransaction:
             autocommit:
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
 
     outcome:
       collection:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/transaction-options.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/transaction-options.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [],
   "tests": [
     {
@@ -68,7 +70,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": null,
@@ -86,7 +87,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -110,7 +110,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -130,7 +129,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -222,7 +220,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -242,7 +239,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -268,7 +264,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -289,7 +284,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -391,7 +385,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -411,7 +404,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -437,7 +429,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -458,7 +449,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -580,7 +570,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -600,7 +589,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -626,7 +614,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -647,7 +634,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -753,7 +739,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -773,7 +758,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -799,7 +783,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -820,7 +803,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -922,7 +904,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -942,7 +923,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -968,7 +948,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -989,7 +968,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -1098,7 +1076,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -1118,7 +1095,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -1142,7 +1118,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
@@ -1163,7 +1138,6 @@
               "txnNumber": {
                 "$numberLong": "2"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
@@ -1250,7 +1224,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -1267,12 +1240,319 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": {
                 "w": 1
               }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "readPreference inherited from client",
+      "clientOptions": {
+        "readPreference": { "mode" : "secondary" }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "count",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "readPreference inherited from defaultTransactionOptions",
+      "clientOptions": {
+        "readPreference": { "mode" : "primary" }
+      },
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readPreference": {
+              "mode": "Secondary"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "count",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "startTransaction overrides readPreference",
+      "clientOptions": {
+        "readPreference": { "mode" : "primary" }
+      },
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readPreference": {
+              "mode": "Primary"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readPreference": {
+                "mode": "Secondary"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "count",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
             },
             "command_name": "commitTransaction",
             "database_name": "admin"

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/transaction-options.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/transaction-options.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: []
 
 tests:
@@ -35,27 +38,25 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -64,28 +65,26 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
               afterClusterTime: 42
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -109,28 +108,26 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
               level: local
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -140,14 +137,13 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
@@ -155,14 +151,13 @@ tests:
               afterClusterTime: 42
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -188,28 +183,26 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
               level: snapshot
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -219,14 +212,13 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
@@ -234,14 +226,13 @@ tests:
               afterClusterTime: 42
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -307,28 +298,26 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
               level: snapshot
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -338,14 +327,13 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
@@ -353,14 +341,13 @@ tests:
               afterClusterTime: 42
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -390,28 +377,26 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
               level: snapshot
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -421,14 +406,13 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
@@ -436,14 +420,13 @@ tests:
               afterClusterTime: 42
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -470,28 +453,26 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
               level: local
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -501,14 +482,13 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
@@ -516,14 +496,13 @@ tests:
               afterClusterTime: 42
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -580,28 +559,26 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
               level: snapshot
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -610,14 +587,13 @@ tests:
           database_name: admin
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 2
             ordered: true
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             readConcern:
@@ -625,14 +601,13 @@ tests:
               afterClusterTime: 42
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "2"
-            stmtId: 1
             startTransaction:
             autocommit: false
             readConcern:
@@ -675,7 +650,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -683,20 +658,18 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             # No writeConcern.
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -705,3 +678,201 @@ tests:
           database_name: admin
 
     outcome: *outcome
+
+  - description: readPreference inherited from client
+
+    clientOptions:
+      readPreference: secondary
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+      - name: insertOne
+        arguments:
+          document:
+            _id: 1
+          session: session0
+        result:
+          insertedId: 1
+      - name: count
+        arguments:
+          filter:
+            _id: 1
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+      - name: commitTransaction
+        arguments:
+          session: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1
+
+  - description: readPreference inherited from defaultTransactionOptions
+
+    clientOptions:
+      readPreference: primary
+
+    sessionOptions:
+      session0:
+        defaultTransactionOptions:
+          readPreference:
+            mode: Secondary
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+      - name: insertOne
+        arguments:
+          document:
+            _id: 1
+          session: session0
+        result:
+          insertedId: 1
+      - name: count
+        arguments:
+          filter:
+            _id: 1
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+      - name: commitTransaction
+        arguments:
+          session: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1
+
+  - description: startTransaction overrides readPreference
+
+    clientOptions:
+      readPreference: primary
+
+    sessionOptions:
+      session0:
+        defaultTransactionOptions:
+          readPreference:
+            mode: Primary
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+          options:
+            readPreference:
+              mode: Secondary
+      - name: insertOne
+        arguments:
+          document:
+            _id: 1
+          session: session0
+        result:
+          insertedId: 1
+      - name: count
+        arguments:
+          filter:
+            _id: 1
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+      - name: commitTransaction
+        arguments:
+          session: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/update.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/update.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [
     {
       "_id": 1
@@ -111,7 +113,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -141,7 +142,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -175,7 +175,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -192,7 +191,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 3,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -338,7 +336,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -368,7 +365,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -402,7 +398,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 2,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -419,7 +414,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 3,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": {

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/update.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/update.yml
@@ -1,3 +1,6 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data:
   - _id: 1
   - _id: 2
@@ -49,7 +52,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {_id: 4}
                 u: {$inc: {x: 1}}
@@ -60,15 +63,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {x: 1}
                 u: {y: 1}
@@ -78,15 +80,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {_id: {$gte: 3}}
                 u: {$set: {z: 1}}
@@ -96,19 +97,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 3
             startTransaction:
             autocommit: false
             writeConcern:
@@ -177,7 +176,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {_id: 4}
                 u: {$inc: {x: 1}}
@@ -188,15 +187,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {x: 1}
                 u: {y: 1}
@@ -206,15 +204,14 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
-            update: test
+            update: *collection_name
             updates:
               - q: {_id: {$gte: 3}}
                 u: {$set: {z: 1}}
@@ -224,19 +221,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 2
             startTransaction:
             autocommit: false
             writeConcern:
           command_name: update
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 3
             startTransaction:
             autocommit: false
             writeConcern:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/write-concern.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/write-concern.json
@@ -1,4 +1,6 @@
 {
+  "database_name": "transaction-tests",
+  "collection_name": "test",
   "data": [],
   "tests": [
     {
@@ -50,7 +52,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -67,7 +68,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": {
@@ -133,7 +133,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -150,7 +149,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -219,7 +217,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -236,7 +233,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": {
@@ -298,7 +294,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 0,
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -315,7 +310,6 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "stmtId": 1,
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/write-concern.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/write-concern.yml
@@ -1,5 +1,8 @@
 # Assumes the default for transactions is the same as for all ops, tests
 # setting the writeConcern to "majority".
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
 data: []
 
 tests:
@@ -25,7 +28,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -33,19 +36,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -78,7 +79,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -86,19 +87,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -134,7 +133,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -142,19 +141,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:
@@ -186,7 +183,7 @@ tests:
     expectations:
       - command_started_event:
           command:
-            insert: test
+            insert: *collection_name
             documents:
               - _id: 1
             ordered: true
@@ -194,19 +191,17 @@ tests:
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 0
             startTransaction: true
             autocommit: false
             writeConcern:
           command_name: insert
-          database_name: transaction-tests
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
               $numberLong: "1"
-            stmtId: 1
             startTransaction:
             autocommit: false
             writeConcern:


### PR DESCRIPTION


Evergreen patch build:

https://evergreen.mongodb.com/version/5af5433cc9ec4463a9755b94
