### PR TITLE
CSHARP-2273: Index.html must be renamed index.html (lowercase)

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -197,7 +197,7 @@ Task("ApiDocs")
 
         var lowerCaseIndexFile = artifactsDocsApiDocsDirectory.CombineWithFilePath("index.html");
         var upperCaseIndexFile = artifactsDocsApiDocsDirectory.CombineWithFilePath("Index.html");
-        MoveFile(lowerCaseIndexFile, upperCaseIndexFile);
+        MoveFile(upperCaseIndexFile, lowerCaseIndexFile);
 
         var apiDocsZipFileName = artifactsDocsApiDocsDirectory.GetDirectoryName() + "-html.zip";
         var apiDocsZipFile = artifactsDocsDirectory.CombineWithFilePath(apiDocsZipFileName);


### PR DESCRIPTION
This turned out to be easy.