### PR TITLE
CSHARP-2213: Disable MaxScan integration test on server 4.0.0 and up.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/SemanticVersion.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/SemanticVersion.cs
@@ -203,7 +203,7 @@ namespace MongoDB.Driver.Core.Misc
         {
             if (!string.IsNullOrEmpty(value))
             {
-                var pattern = @"(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+)(-(?<preRelease>.+))?)?";
+                var pattern = @"(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+)(-(?<preRelease>.*))?)?";
                 var match = Regex.Match((string)value, pattern);
                 if (match.Success)
                 {

--- a/src/MongoDB.Driver.Core/MongoException.cs
+++ b/src/MongoDB.Driver.Core/MongoException.cs
@@ -15,9 +15,9 @@
 
 using System;
 using System.Collections.Generic;
+using MongoDB.Driver.Core.Misc;
 #if NET45
 using System.Runtime.Serialization;
-using MongoDB.Driver.Core.Misc;
 #endif
 
 namespace MongoDB.Driver

--- a/tests/MongoDB.Driver.Legacy.Tests/MongoCollectionTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/MongoCollectionTests.cs
@@ -1563,9 +1563,10 @@ namespace MongoDB.Driver.Tests
             // note: the hits are unordered
         }
 
-        [Fact]
+        [SkippableFact]
         public void TestFindWithMaxScan()
         {
+            RequireServer.Check().VersionLessThan("4.1.0-");
             _collection.Drop();
             var docs = Enumerable.Range(0, 10).Select(x => new BsonDocument("_id", x));
             _collection.InsertBatch(docs);


### PR DESCRIPTION
MaxScan integration test is not failing locally (yet) but is failing on Evergreen against latest.

Evergreen patch:

https://evergreen.mongodb.com/version/5b22673fe3c3310715577501

I only scheduled one task to run against latest.