### PR TITLE
Remove maxScan from command monitoring find.json file.

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/command-monitoring/tests/find.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/command-monitoring/tests/find.json
@@ -95,7 +95,6 @@
             "$max": {
               "_id": 6
             },
-            "$maxScan": 5000,
             "$maxTimeMS": 6000,
             "$min": {
               "_id": 0
@@ -126,7 +125,6 @@
               "max": {
                 "_id": 6
               },
-              "maxScan": 5000,
               "maxTimeMS": 6000,
               "min": {
                 "_id": 0


### PR DESCRIPTION
I looked into updating all the command monitoring JSON files but the format has changed and I don't want to tackle that big a job right now. I just want to get Evergreen green.