### PR TITLE
CSHARP-2309: Transaction JSON tests should be run using the async API also.

### DIFF
--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAbortTransactionTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAbortTransactionTest.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 
@@ -43,6 +44,11 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
         protected override void CallMethod(CancellationToken cancellationToken)
         {
             _session.AbortTransaction(cancellationToken);
+        }
+
+        protected override Task CallMethodAsync(CancellationToken cancellationToken)
+        {
+            return _session.AbortTransactionAsync(cancellationToken);
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenCommitTransactionTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenCommitTransactionTest.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 
@@ -43,6 +44,11 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
         protected override void CallMethod(CancellationToken cancellationToken)
         {
             _session.CommitTransaction(cancellationToken);
+        }
+
+        protected override Task CallMethodAsync(CancellationToken cancellationToken)
+        {
+            return _session.CommitTransactionAsync(cancellationToken);
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenStartTransactionTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenStartTransactionTest.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 
@@ -46,6 +47,12 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
         protected override void CallMethod(CancellationToken cancellationToken)
         {
             _session.StartTransaction(_options);
+        }
+
+        protected override Task CallMethodAsync(CancellationToken cancellationToken)
+        {
+            _session.StartTransaction(_options); // there is no async version, just call the sync version
+            return Task.FromResult(true);
         }
 
         protected override void SetArgument(string name, BsonValue value)


### PR DESCRIPTION
This work is based on the csharp2287 branch.

No changes were necessary to the driver (other than the fix made in csharp2287). All the transaction tests pass using both the sync and the async APIs.