### PR TITLE
CSHARP-2124: Automate Atlas connectivity tests.

### DIFF
--- a/CSharpDriver.sln
+++ b/CSharpDriver.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2035
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoDB.Bson", "src\MongoDB.Bson\MongoDB.Bson.csproj", "{0E9A3A2A-49CD-4F6C-847C-DC79B4B65CE6}"
 EndProject
@@ -40,6 +40,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{82C26C54-8760-4F9F-AC64-00E72F49355C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{48C67B2A-FD93-4E81-BE98-5E4491E57A51}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AtlasConnectivity.Tests", "tests\AtlasConnectivity.Tests\AtlasConnectivity.Tests.csproj", "{99C4C279-8ACF-43F0-88DE-4AE382AD77B9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -115,6 +117,10 @@ Global
 		{F7B7D81A-CA16-4CD7-8B6C-444280EA37C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F7B7D81A-CA16-4CD7-8B6C-444280EA37C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7B7D81A-CA16-4CD7-8B6C-444280EA37C1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99C4C279-8ACF-43F0-88DE-4AE382AD77B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99C4C279-8ACF-43F0-88DE-4AE382AD77B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99C4C279-8ACF-43F0-88DE-4AE382AD77B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99C4C279-8ACF-43F0-88DE-4AE382AD77B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -137,5 +143,9 @@ Global
 		{6B5D1EA6-1088-4122-B8C4-B341822C7915} = {82C26C54-8760-4F9F-AC64-00E72F49355C}
 		{1537C58E-BECD-4ED2-A900-1AFBB601D2B2} = {48C67B2A-FD93-4E81-BE98-5E4491E57A51}
 		{F7B7D81A-CA16-4CD7-8B6C-444280EA37C1} = {48C67B2A-FD93-4E81-BE98-5E4491E57A51}
+		{99C4C279-8ACF-43F0-88DE-4AE382AD77B9} = {48C67B2A-FD93-4E81-BE98-5E4491E57A51}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {03215EF2-473F-4B62-B505-1E3AF774EA7B}
 	EndGlobalSection
 EndGlobal

--- a/build.cake
+++ b/build.cake
@@ -136,7 +136,20 @@ Task("TestNet45")
     .IsDependentOn("BuildNet45")
     .Does(() =>
     {
-        var testAssemblies = GetFiles("./tests/**/bin/" + configuration + "/*Tests.dll");
+        var testAssemblies = new List<FilePath>();
+        var testProjectNames = new []
+        {
+            "MongoDB.Bson.Tests",
+            "MongoDB.Driver.Core.Tests",
+            "MongoDB.Driver.Tests",
+            "MongoDB.Driver.GridFS.Tests",
+            "MongoDB.Driver.Legacy.Tests"
+        };
+        foreach (var testProjectName in testProjectNames)
+        {
+            var testAssembly = testsDirectory.CombineWithFilePath($"{testProjectName}/bin/{configuration}/{testProjectName}.dll");
+            testAssemblies.Add(testAssembly);
+        }
         var testSettings = new XUnit2Settings
         {
             Parallelism = ParallelismOption.None,
@@ -170,6 +183,28 @@ Task("TestNetStandard15")
             };
             DotNetCoreTest(testSettings, testProjectFile, xunitSettings);
         }
+    });
+
+Task("TestAtlasConnectivity")
+    .IsDependentOn("BuildNet45")
+    .Does(() =>
+    {
+        var testAssemblies = new List<FilePath>();
+        var testProjectNames = new []
+        {
+            "AtlasConnectivity.Tests"
+        };
+        foreach (var testProjectName in testProjectNames)
+        {
+            var testAssembly = testsDirectory.CombineWithFilePath($"{testProjectName}/bin/{configuration}/{testProjectName}.dll");
+            testAssemblies.Add(testAssembly);
+        }
+        var testSettings = new XUnit2Settings
+        {
+            Parallelism = ParallelismOption.None,
+            ToolTimeout = TimeSpan.FromMinutes(30)
+        };
+        XUnit2(testAssemblies, testSettings);
     });
 
 Task("Docs")

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -217,6 +217,16 @@ functions:
           ${PREPARE_SHELL}
           AUTH=${AUTH} SSL=${SSL} MONGODB_URI="${MONGODB_URI}" TOPOLOGY=${TOPOLOGY} OS=${OS} evergreen/run-tests.sh
 
+  run-atlas-connectivity-tests:
+    - command: shell.exec
+      type: test
+      params:
+        silent: true
+        working_dir: mongo-csharp-driver
+        script: |
+          # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
+          ATLAS_FREE="${ATLAS_FREE}" ATLAS_REPLICA="${ATLAS_REPLICA}" ATLAS_SHARDED="${ATLAS_SHARDED}" ATLAS_TLS11="${ATLAS_TLS11}" ATLAS_TLS12="${ATLAS_TLS12}" evergreen/run-atlas-connectivity-tests.sh
+
   run-plain-auth-tests:
     - command: shell.exec
       type: test
@@ -331,6 +341,13 @@ tasks:
         - func: bootstrap-mongo-orchestration
         - func: run-tests
 
+    - name: atlas-connectivity-tests
+      depends_on:
+        - variant: windows-64-compile
+          name: compile
+      commands:
+        - func: run-atlas-connectivity-tests
+
     - name: plain-auth-tests
       depends_on:
         - variant: windows-64-compile
@@ -442,6 +459,13 @@ buildvariants:
   tags: ["tests-variant"]
   tasks:
      - name: test
+
+- name: atlas-connectivity-tests
+  display_name: "Atlas Connectivity Tests"
+  run_on:
+    - windows-64-vs2015-small
+  tasks:
+    - name: atlas-connectivity-tests
 
 # - name: plain-auth-tests
 #   display_name: "PLAIN (LDAP) Auth tests"

--- a/evergreen/run-atlas-connectivity-tests.sh
+++ b/evergreen/run-atlas-connectivity-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# DO NOT set xtrace
+set -o errexit  # Exit the script with error if any of the commands fail
+
+############################################
+#            Main Program                  #
+############################################
+
+# Provision the correct connection string and set up SSL if needed
+for var in TMP TEMP NUGET_PACKAGES NUGET_HTTP_CACHE_PATH APPDATA; do setx $var z:\\data\\tmp; export $var=z:\\data\\tmp; done
+powershell.exe .\\build.ps1 -target TestAtlasConnectivity

--- a/tests/AtlasConnectivity.Tests/AtlasConnectivity.Tests.csproj
+++ b/tests/AtlasConnectivity.Tests/AtlasConnectivity.Tests.csproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{99C4C279-8ACF-43F0-88DE-4AE382AD77B9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AtlasConnectivity.Tests</RootNamespace>
+    <AssemblyName>AtlasConnectivity.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FluentAssertions, Version=4.5.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.5.0\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.5.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.5.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ConnectivityTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MongoDB.Bson\MongoDB.Bson.csproj">
+      <Project>{0e9a3a2a-49cd-4f6c-847c-dc79b4b65ce6}</Project>
+      <Name>MongoDB.Bson</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\MongoDB.Driver.Core\MongoDB.Driver.Core.csproj">
+      <Project>{DA56482A-5D8F-41E0-85E6-1F22B310F91B}</Project>
+      <Name>MongoDB.Driver.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\MongoDB.Driver\MongoDB.Driver.csproj">
+      <Project>{AE5166CD-76B0-4911-BD80-CED9521F37A1}</Project>
+      <Name>MongoDB.Driver</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MongoDB.Bson.TestHelpers\MongoDB.Bson.TestHelpers.csproj">
+      <Project>{6AC4638E-EC69-46AA-B6AA-C5CF227D14AE}</Project>
+      <Name>MongoDB.Bson.TestHelpers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MongoDB.Driver.Core.TestHelpers\MongoDB.Driver.Core.TestHelpers.csproj">
+      <Project>{F7B7D81A-CA16-4CD7-8B6C-444280EA37C1}</Project>
+      <Name>MongoDB.Driver.Core.TestHelpers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MongoDB.Driver.TestHelpers\MongoDB.Driver.TestHelpers.csproj">
+      <Project>{89B92FFF-4126-4D9A-93C8-2BD7E0CD82FF}</Project>
+      <Name>MongoDB.Driver.TestHelpers</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/AtlasConnectivity.Tests/ConnectivityTests.cs
+++ b/tests/AtlasConnectivity.Tests/ConnectivityTests.cs
@@ -1,0 +1,62 @@
+﻿/* Copyright 2018-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.Driver.TestHelpers;
+using MongoDB.Driver.Tests;
+using Xunit;
+
+namespace AtlasConnectivity.Tests
+{
+    public class ConnectivityTests
+    {
+        [Theory]
+        [InlineData("ATLAS_FREE")]
+        [InlineData("ATLAS_REPLICA")]
+        [InlineData("ATLAS_SHARDED")]
+        [InlineData("ATLAS_TLS11")]
+        [InlineData("ATLAS_TLS12")]
+        public void Connection_to_Atlas_should_work(string environmentVariableName)
+        {
+            var connectionString = Environment.GetEnvironmentVariable(environmentVariableName);
+            connectionString.Should().NotBeNull();
+
+            using (var client = CreateDisposableClient(connectionString))
+            {
+                // test that a command that doesn't require auth completes normally
+                var adminDatabase = client.GetDatabase("admin");
+                var isMasterCommand = new BsonDocument("ismaster", 1);
+                var isMasterResult = adminDatabase.RunCommand<BsonDocument>(isMasterCommand);
+
+                // test that a command that does require auth completes normally
+                var database = client.GetDatabase("test");
+                var collection = database.GetCollection<BsonDocument>("test");
+                var emptyFilter = Builders<BsonDocument>.Filter.Empty;
+                var count = collection.CountDocuments(emptyFilter);
+            }
+        }
+
+        // private methods
+        private DisposableMongoClient CreateDisposableClient(string connectionString)
+        {
+            var clientSettings = MongoClientSettings.FromUrl(new MongoUrl(connectionString));
+            var client = new MongoClient(clientSettings);
+            return new DisposableMongoClient(client);
+        }
+    }
+}

--- a/tests/AtlasConnectivity.Tests/Properties/AssemblyInfo.cs
+++ b/tests/AtlasConnectivity.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,52 @@
+﻿/* Copyright 2018-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AtlasConnectivity.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("MongoDB Inc.")]
+[assembly: AssemblyProduct("AtlasConnectivity.Tests")]
+[assembly: AssemblyCopyright("Copyright © 2018-present MongoDB Inc.")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("99c4c279-8acf-43f0-88de-4ae382ad77b9")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("unofficial")]

--- a/tests/AtlasConnectivity.Tests/packages.config
+++ b/tests/AtlasConnectivity.Tests/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FluentAssertions" version="4.5.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Evergreen  patch build here:

https://evergreen.mongodb.com/version/5b451b1ee3c3317160791dd4

Note that the failed tasks have nothing to do with Atlas connectivity tests. Some are mongo orchestration failures and some are the race conditions we have seen before in our own tests.