### PR TITLE
CSHARP-2339: Only call AbortTransaction from Dispose when appropriate.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Bindings/CoreSession.cs
+++ b/src/MongoDB.Driver.Core/Core/Bindings/CoreSession.cs
@@ -322,13 +322,19 @@ namespace MongoDB.Driver.Core.Bindings
             {
                 if (_currentTransaction != null)
                 {
-                    try
+                    switch (_currentTransaction.State)
                     {
-                        AbortTransaction(CancellationToken.None);
-                    }
-                    catch
-                    {
-                        // ignore exceptions
+                        case CoreTransactionState.Starting:
+                        case CoreTransactionState.InProgress:
+                            try
+                            {
+                                AbortTransaction(CancellationToken.None);
+                            }
+                            catch
+                            {
+                                // ignore exceptions
+                            }
+                            break;
                     }
                 }
 


### PR DESCRIPTION
Fix is easy. Don't think there's any easy way to write a test.