### PR TITLE
CSHARP-2005: Invalid BinaryConnection state transition from 4 to Failed.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -676,7 +676,7 @@ namespace MongoDB.Driver.Core.Connections
                 if (!_connection._state.TryChange(State.Connecting, State.Failed) && !_connection._state.TryChange(State.Initializing, State.Failed))
                 {
                     var currentState = _connection._state.Value;
-                    if (currentState != State.Disposed)
+                    if (currentState != State.Failed && currentState != State.Disposed)
                     {
                         throw new InvalidOperationException($"Invalid BinaryConnection state transition from {currentState} to Failed.");
                     }


### PR DESCRIPTION
The fix is trivial, but the hard part was trying to figure how this could ever happen and whether I could reproduce it.

As far as I can tell the ONLY way this could happen is if there is a socket exception while sending or receiving a message WHILE authenticating a newly opened connection. Can't really test that.

In that case the socket exception results in the connection being set to Failed, and then the initialization code tries to set it to Failed again. The easy fix is to treat setting the state to Failed as a no-op if the state has already been set to Failed.