### PR TITLE
CSHARP-2215: Only allow scalar value for array field where appropriate

### DIFF
--- a/src/MongoDB.Driver/FieldDefinition.cs
+++ b/src/MongoDB.Driver/FieldDefinition.cs
@@ -22,7 +22,6 @@ using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Linq;
 using MongoDB.Driver.Linq.Expressions;
 using MongoDB.Driver.Linq.Processors;
-using MongoDB.Driver.Linq.Translators;
 
 namespace MongoDB.Driver
 {
@@ -179,10 +178,12 @@ namespace MongoDB.Driver
         /// <returns>A <see cref="RenderedFieldDefinition{TField}"/>.</returns>
         public abstract RenderedFieldDefinition<TField> Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry);
 
+        /// <summary>
         /// Renders the field to a <see cref="RenderedFieldDefinition{TField}"/>.
-        /// <param name="documentSerializer"></param>
-        /// <param name="serializerRegistry"></param>
-        /// <param name="allowScalarValueForArrayField"></param>
+        /// </summary>
+        /// <param name="documentSerializer">The document serializer.</param>
+        /// <param name="serializerRegistry">The serializer registry.</param>
+        /// <param name="allowScalarValueForArrayField">Whether a scalar value is allowed for an array field.</param>
         /// <returns>A <see cref="RenderedFieldDefinition{TField}"/>.</returns>
         public virtual RenderedFieldDefinition<TField> Render(
             IBsonSerializer<TDocument> documentSerializer, 

--- a/src/MongoDB.Driver/FilterDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/FilterDefinitionBuilder.cs
@@ -423,7 +423,7 @@ namespace MongoDB.Driver
         /// <returns>An equality filter.</returns>
         public FilterDefinition<TDocument> Eq<TField>(FieldDefinition<TDocument, TField> field, TField value)
         {
-            return new SimpleFilterDefinition<TDocument, TField>(field, value);
+            return new SimpleFilterDefinition<TDocument, TField>(field, value, allowScalarValueForArrayField: true);
         }
 
         /// <summary>
@@ -661,7 +661,7 @@ namespace MongoDB.Driver
         /// <returns>A greater than filter.</returns>
         public FilterDefinition<TDocument> Gt<TField>(FieldDefinition<TDocument, TField> field, TField value)
         {
-            return new OperatorFilterDefinition<TDocument, TField>("$gt", field, value);
+            return new OperatorFilterDefinition<TDocument, TField>("$gt", field, value, allowScalarValueForArrayField: true);
         }
 
         /// <summary>
@@ -733,7 +733,7 @@ namespace MongoDB.Driver
         /// <returns>A greater than or equal filter.</returns>
         public FilterDefinition<TDocument> Gte<TField>(FieldDefinition<TDocument, TField> field, TField value)
         {
-            return new OperatorFilterDefinition<TDocument, TField>("$gte", field, value);
+            return new OperatorFilterDefinition<TDocument, TField>("$gte", field, value, allowScalarValueForArrayField: true);
         }
 
         /// <summary>
@@ -781,7 +781,7 @@ namespace MongoDB.Driver
         /// <returns>An in filter.</returns>
         public FilterDefinition<TDocument> In<TField>(FieldDefinition<TDocument, TField> field, IEnumerable<TField> values)
         {
-            return new SingleItemAsArrayOperatorFilterDefinition<TDocument, TField>("$in", field, values);
+            return new SingleItemAsArrayOperatorFilterDefinition<TDocument, TField>("$in", field, values, allowScalarValueForArrayField: true);
         }
 
         /// <summary>
@@ -803,7 +803,7 @@ namespace MongoDB.Driver
         /// <returns>A schema filter.</returns>
         public FilterDefinition<TDocument> JsonSchema(BsonDocument schema)
         {
-            return new BsonDocumentFilterDefinition<TDocument>(new BsonDocument("$jsonSchema", schema)); 
+            return new BsonDocumentFilterDefinition<TDocument>(new BsonDocument("$jsonSchema", schema));
         }
 
         /// <summary>
@@ -839,7 +839,7 @@ namespace MongoDB.Driver
         /// <returns>A less than filter.</returns>
         public FilterDefinition<TDocument> Lt<TField>(FieldDefinition<TDocument, TField> field, TField value)
         {
-            return new OperatorFilterDefinition<TDocument, TField>("$lt", field, value);
+            return new OperatorFilterDefinition<TDocument, TField>("$lt", field, value, allowScalarValueForArrayField: true);
         }
 
         /// <summary>
@@ -911,7 +911,7 @@ namespace MongoDB.Driver
         /// <returns>A less than or equal filter.</returns>
         public FilterDefinition<TDocument> Lte<TField>(FieldDefinition<TDocument, TField> field, TField value)
         {
-            return new OperatorFilterDefinition<TDocument, TField>("$lte", field, value);
+            return new OperatorFilterDefinition<TDocument, TField>("$lte", field, value, allowScalarValueForArrayField: true);
         }
 
         /// <summary>
@@ -983,7 +983,7 @@ namespace MongoDB.Driver
         /// <returns>A not equal filter.</returns>
         public FilterDefinition<TDocument> Ne<TField>(FieldDefinition<TDocument, TField> field, TField value)
         {
-            return new OperatorFilterDefinition<TDocument, TField>("$ne", field, value);
+            return new OperatorFilterDefinition<TDocument, TField>("$ne", field, value, allowScalarValueForArrayField: true);
         }
 
         /// <summary>
@@ -2019,17 +2019,23 @@ namespace MongoDB.Driver
         private readonly string _operatorName;
         private readonly FieldDefinition<TDocument, TField> _field;
         private readonly TField _value;
+        private readonly bool _allowScalarValueForArrayField;
 
-        public OperatorFilterDefinition(string operatorName, FieldDefinition<TDocument, TField> field, TField value)
+        public OperatorFilterDefinition(
+            string operatorName,
+            FieldDefinition<TDocument, TField> field,
+            TField value,
+            bool allowScalarValueForArrayField = false)
         {
             _operatorName = Ensure.IsNotNull(operatorName, operatorName);
             _field = Ensure.IsNotNull(field, nameof(field));
             _value = value;
+            _allowScalarValueForArrayField = allowScalarValueForArrayField;
         }
 
         public override BsonDocument Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            var renderedField = _field.Render(documentSerializer, serializerRegistry);
+            var renderedField = _field.Render(documentSerializer, serializerRegistry, _allowScalarValueForArrayField);
 
             var document = new BsonDocument();
             using (var bsonWriter = new BsonDocumentWriter(document))
@@ -2108,16 +2114,21 @@ namespace MongoDB.Driver
     {
         private readonly FieldDefinition<TDocument, TField> _field;
         private readonly TField _value;
+        private readonly bool _allowScalarValueForArrayField;
 
-        public SimpleFilterDefinition(FieldDefinition<TDocument, TField> field, TField value)
+        public SimpleFilterDefinition(
+            FieldDefinition<TDocument, TField> field,
+            TField value,
+            bool allowScalarValueForArrayField = false)
         {
             _field = Ensure.IsNotNull(field, nameof(field));
             _value = value;
+            _allowScalarValueForArrayField = allowScalarValueForArrayField;
         }
 
         public override BsonDocument Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            var renderedField = _field.Render(documentSerializer, serializerRegistry);
+            var renderedField = _field.Render(documentSerializer, serializerRegistry, _allowScalarValueForArrayField);
 
             var document = new BsonDocument();
             using (var bsonWriter = new BsonDocumentWriter(document))
@@ -2138,17 +2149,23 @@ namespace MongoDB.Driver
         private readonly string _operatorName;
         private readonly FieldDefinition<TDocument, TField> _field;
         private readonly IEnumerable<TField> _values;
+        private readonly bool _allowScalarValueForArrayField;
 
-        public SingleItemAsArrayOperatorFilterDefinition(string operatorName, FieldDefinition<TDocument, TField> field, IEnumerable<TField> values)
+        public SingleItemAsArrayOperatorFilterDefinition(
+            string operatorName,
+            FieldDefinition<TDocument, TField> field,
+            IEnumerable<TField> values,
+            bool allowScalarValueForArrayField = false)
         {
             _operatorName = Ensure.IsNotNull(operatorName, operatorName);
             _field = Ensure.IsNotNull(field, nameof(field));
             _values = Ensure.IsNotNull(values, nameof(values));
+            _allowScalarValueForArrayField = allowScalarValueForArrayField;
         }
 
         public override BsonDocument Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            var renderedField = _field.Render(documentSerializer, serializerRegistry);
+            var renderedField = _field.Render(documentSerializer, serializerRegistry, _allowScalarValueForArrayField);
 
             var document = new BsonDocument();
             using (var bsonWriter = new BsonDocumentWriter(document))

--- a/tests/MongoDB.Driver.Tests/FilterDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/FilterDefinitionBuilderTests.cs
@@ -286,6 +286,7 @@ namespace MongoDB.Driver.Tests
             Assert(subject.Eq("firstName", "Jim"), "{firstName: 'Jim'}");
             Assert(subject.Eq(x => x.FavoriteColors, new[] { "yellow", "green" }), "{colors: ['yellow', 'green']}");
             Assert(subject.Eq("FavoriteColors", new[] { "yellow", "green" }), "{colors: ['yellow', 'green']}");
+            Assert(subject.Eq("FavoriteColors", "yellow"), "{colors: 'yellow'}");
 
             Assert(subject.AnyEq(x => x.FavoriteColors, "yellow"), "{colors: 'yellow'}");
             Assert(subject.AnyEq("FavoriteColors", "yellow"), "{colors: 'yellow'}");
@@ -493,6 +494,7 @@ namespace MongoDB.Driver.Tests
             var subject = CreateSubject<Person>();
             Assert(subject.Gt(x => x.Age, 10), "{age: {$gt: 10}}");
             Assert(subject.Gt("Age", 10), "{age: {$gt: 10}}");
+            Assert(subject.Gt("FavoriteColors", "green"), "{colors: {$gt: 'green'}}");
 
             Assert(subject.AnyGt(x => x.FavoriteColors, "green"), "{colors: {$gt: 'green'}}");
             Assert(subject.AnyGt("FavoriteColors", "green"), "{colors: {$gt: 'green'}}");
@@ -513,6 +515,7 @@ namespace MongoDB.Driver.Tests
             var subject = CreateSubject<Person>();
             Assert(subject.Gte(x => x.Age, 10), "{age: {$gte: 10}}");
             Assert(subject.Gte("Age", 10), "{age: {$gte: 10}}");
+            Assert(subject.Gte("FavoriteColors", "green"), "{colors: {$gte: 'green'}}");
 
             Assert(subject.AnyGte(x => x.FavoriteColors, "green"), "{colors: {$gte: 'green'}}");
             Assert(subject.AnyGte("FavoriteColors", "green"), "{colors: {$gte: 'green'}}");
@@ -533,6 +536,7 @@ namespace MongoDB.Driver.Tests
             var subject = CreateSubject<Person>();
             Assert(subject.In(x => x.Age, new[] { 10, 20 }), "{age: {$in: [10, 20]}}");
             Assert(subject.In("Age", new[] { 10, 20 }), "{age: {$in: [10, 20]}}");
+            Assert(subject.In("FavoriteColors", new[] { "blue", "green" }), "{colors: {$in: ['blue','green']}}");
 
             Assert(subject.AnyIn(x => x.FavoriteColors, new[] { "blue", "green" }), "{colors: {$in: ['blue','green']}}");
             Assert(subject.AnyIn("FavoriteColors", new[] { "blue", "green" }), "{colors: {$in: ['blue','green']}}");
@@ -598,6 +602,7 @@ namespace MongoDB.Driver.Tests
             var subject = CreateSubject<Person>();
             Assert(subject.Lt(x => x.Age, 10), "{age: {$lt: 10}}");
             Assert(subject.Lt("Age", 10), "{age: {$lt: 10}}");
+            Assert(subject.Lt("FavoriteColors", "green"), "{colors: {$lt: 'green'}}");
 
             Assert(subject.AnyLt(x => x.FavoriteColors, "green"), "{colors: {$lt: 'green'}}");
             Assert(subject.AnyLt("FavoriteColors", "green"), "{colors: {$lt: 'green'}}");
@@ -618,6 +623,7 @@ namespace MongoDB.Driver.Tests
             var subject = CreateSubject<Person>();
             Assert(subject.Lte(x => x.Age, 10), "{age: {$lte: 10}}");
             Assert(subject.Lte("Age", 10), "{age: {$lte: 10}}");
+            Assert(subject.Lte("FavoriteColors", "green"), "{colors: {$lte: 'green'}}");
 
             Assert(subject.AnyLte(x => x.FavoriteColors, "green"), "{colors: {$lte: 'green'}}");
             Assert(subject.AnyLte("FavoriteColors", "green"), "{colors: {$lte: 'green'}}");
@@ -657,6 +663,7 @@ namespace MongoDB.Driver.Tests
             var subject = CreateSubject<Person>();
             Assert(subject.Ne(x => x.Age, 10), "{age: {$ne: 10}}");
             Assert(subject.Ne("Age", 10), "{age: {$ne: 10}}");
+            Assert(subject.Ne("FavoriteColors", "green"), "{colors: {$ne: 'green'}}");
 
             Assert(subject.AnyNe(x => x.FavoriteColors, "green"), "{colors: {$ne: 'green'}}");
             Assert(subject.AnyNe("FavoriteColors", "green"), "{colors: {$ne: 'green'}}");


### PR DESCRIPTION
Evergreen patch build:

https://evergreen.mongodb.com/version/5c1aa1e92fbabef758a14a3b