### PR TITLE
CSHARP-2453: Update DnsClient reference to 1.2.0.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -457,11 +457,11 @@ namespace MongoDB.Driver.Core.Configuration
             var host = GetHostNameForDns();
 
             var client = new LookupClient();
-            var response = client.Query(srvPrefix + host, QueryType.SRV);
+            var response = client.Query(srvPrefix + host, QueryType.SRV, QueryClass.IN);
             var hosts = GetHostsFromResponse(response);
             ValidateResolvedHosts(host, hosts);
 
-            response = client.Query(host, QueryType.TXT);
+            response = client.Query(host, QueryType.TXT, QueryClass.IN);
             var options = GetOptionsFromResponse(response);
 
             var resolvedOptions = GetResolvedOptions(options);
@@ -485,11 +485,11 @@ namespace MongoDB.Driver.Core.Configuration
             string host = GetHostNameForDns();
 
             var client = new LookupClient();
-            var response = await client.QueryAsync(srvPrefix + host, QueryType.SRV, cancellationToken).ConfigureAwait(false);
+            var response = await client.QueryAsync(srvPrefix + host, QueryType.SRV, QueryClass.IN, cancellationToken).ConfigureAwait(false);
             var hosts = GetHostsFromResponse(response);
             ValidateResolvedHosts(host, hosts);
 
-            response = await client.QueryAsync(host, QueryType.TXT, cancellationToken).ConfigureAwait(false);
+            response = await client.QueryAsync(host, QueryType.TXT, QueryClass.IN, cancellationToken).ConfigureAwait(false);
             var options = GetOptionsFromResponse(response);
 
             var resolvedOptions = GetResolvedOptions(options);

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -42,7 +42,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DnsClient" Version="1.0.7" />
+    <PackageReference Include="DnsClient" Version="1.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Evergreen patch build:

https://evergreen.mongodb.com/version/5c1be7c4c9ec4427483e45b6