### PR TITLE
CSHARP-2494: Change C# language version to 7.3.

### DIFF
--- a/src/MongoDB.Bson/MongoDB.Bson.csproj
+++ b/src/MongoDB.Bson/MongoDB.Bson.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <CodeAnalysisRuleSet>..\..\MongoDBLegacy.ruleset</CodeAnalysisRuleSet>

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <CodeAnalysisRuleSet>..\..\MongoDB.ruleset</CodeAnalysisRuleSet>

--- a/src/MongoDB.Driver.GridFS/MongoDB.Driver.GridFS.csproj
+++ b/src/MongoDB.Driver.GridFS/MongoDB.Driver.GridFS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <CodeAnalysisRuleSet>..\..\MongoDB.ruleset</CodeAnalysisRuleSet>

--- a/src/MongoDB.Driver.Legacy/MongoDB.Driver.Legacy.csproj
+++ b/src/MongoDB.Driver.Legacy/MongoDB.Driver.Legacy.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <CodeAnalysisRuleSet>..\..\MongoDBLegacy.ruleset</CodeAnalysisRuleSet>

--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <CodeAnalysisRuleSet>..\..\MongoDB.ruleset</CodeAnalysisRuleSet>

--- a/tests/AtlasConnectivity.Tests/AtlasConnectivity.Tests.csproj
+++ b/tests/AtlasConnectivity.Tests/AtlasConnectivity.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>

--- a/tests/MongoDB.Bson.TestHelpers/MongoDB.Bson.TestHelpers.csproj
+++ b/tests/MongoDB.Bson.TestHelpers/MongoDB.Bson.TestHelpers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>

--- a/tests/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
+++ b/tests/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>

--- a/tests/MongoDB.Driver.Core.TestHelpers/MongoDB.Driver.Core.TestHelpers.csproj
+++ b/tests/MongoDB.Driver.Core.TestHelpers/MongoDB.Driver.Core.TestHelpers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>

--- a/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
+++ b/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>

--- a/tests/MongoDB.Driver.Examples/MongoDB.Driver.Examples.csproj
+++ b/tests/MongoDB.Driver.Examples/MongoDB.Driver.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>

--- a/tests/MongoDB.Driver.GridFS.Tests/MongoDB.Driver.GridFS.Tests.csproj
+++ b/tests/MongoDB.Driver.GridFS.Tests/MongoDB.Driver.GridFS.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>

--- a/tests/MongoDB.Driver.Legacy.TestHelpers/MongoDB.Driver.Legacy.TestHelpers.csproj
+++ b/tests/MongoDB.Driver.Legacy.TestHelpers/MongoDB.Driver.Legacy.TestHelpers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>

--- a/tests/MongoDB.Driver.Legacy.Tests/MongoDB.Driver.Legacy.Tests.csproj
+++ b/tests/MongoDB.Driver.Legacy.Tests/MongoDB.Driver.Legacy.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>

--- a/tests/MongoDB.Driver.TestHelpers/MongoDB.Driver.TestHelpers.csproj
+++ b/tests/MongoDB.Driver.TestHelpers/MongoDB.Driver.TestHelpers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>

--- a/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
+++ b/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>

--- a/tests/SkippableTests/SkippableTests.csproj
+++ b/tests/SkippableTests/SkippableTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Just a quick PR to prove that we can change the C# language to 7.3 with no source code changes needed.

Evergreen patch build:

https://evergreen.mongodb.com/version/5c535bba3627e021794a61ca

I tried using named Tuples and got the expected compiler error since we are still targeting .NET Framework 4.5.2 which doesn't have the classes required for named Tuple support. I would say this confirms the assertion that it is safe to increase the C# language version without affecting our users since the compiler itself will only allow us to use the new C# language features that are compatible with .NET Framework 4.5.2 (and NET Standard 1.5).