### PR TITLE
Added release notes for v2.8.1.

### DIFF
--- a/Release Notes/Release Notes v2.8.1.md
+++ b/Release Notes/Release Notes v2.8.1.md
@@ -1,0 +1,19 @@
+# .NET Driver Version 2.8.1 Release Notes
+
+This is a patch release that fixes a few bugs reported since 2.8.0 was released.
+
+An online version of these release notes is available at:
+
+https://github.com/mongodb/mongo-csharp-driver/blob/v2.8.x/Release%20Notes/Release%20Notes%20v2.8.1.md
+
+The full list of JIRA issues resolved in this release is available at:
+
+https://jira.mongodb.org/issues/?jql=project%20%3D%20CSHARP%20AND%20fixVersion%20%3D%202.8.1%20ORDER%20BY%20key%20ASC
+
+Documentation on the .NET driver can be found at:
+
+http://mongodb.github.io/mongo-csharp-driver/
+
+Upgrading
+
+There are no known backwards breaking changes in this release.


### PR DESCRIPTION
Probably no need to say anything more than this, which is patterned after our release notes for 2.7.1.