### PR TITLE
CSHARP-2644: Add a convention for storing an _id declared as string in a POCO as ObjectId in the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Please see our [guidelines](CONTRIBUTING.md) for contributing to the driver.
 * Daniel Goldman            daniel@stackwave.com
 * Simon Green               simon@captaincodeman.com
 * James Hadwen              james.hadwen@sociustec.com
+* Nuri Halperin             https://github.com/nurih
 * Jacob Jewell              jacobjewell@eflexsystems.com
 * Danny Kendrick            https://github.com/dkendrick
 * Ruslan Khasanbaev         https://github.com/flaksirus

--- a/src/MongoDB.Bson/Serialization/Conventions/StringIdStoredAsObjectIdConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/StringIdStoredAsObjectIdConvention.cs
@@ -1,0 +1,44 @@
+﻿using MongoDB.Bson.Serialization.IdGenerators;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace MongoDB.Bson.Serialization.Conventions
+{
+    /// <summary>
+    /// A convention that sets representation of a string id class member to ObjectId in BSON with a StringObjectIdGenerator.
+    /// </summary>
+    public class StringIdStoredAsObjectIdConvention : ConventionBase, IMemberMapConvention
+    {
+        /// <summary>
+        /// Applies a post processing modification to the class map.
+        /// </summary>
+        /// <param name="memberMap">The BsonMemberMap map.</param>
+        /// <remarks>This method sets both the serializer and the IdGenerator on the id member field.</remarks>
+        public void Apply(BsonMemberMap memberMap)
+        {
+            var idMemberMap = memberMap.ClassMap?.IdMemberMap;
+
+            if (idMemberMap == null)
+            {
+                return;
+            }
+
+            if (idMemberMap.MemberType != typeof(string))
+            {
+                return;
+            }
+
+            if (idMemberMap.IdGenerator != null)
+            {
+                return;
+            }
+
+            var idSerializer = idMemberMap.GetSerializer();
+
+            if (idSerializer is StringSerializer stringSerializer && stringSerializer.Representation == BsonType.String)
+            {
+                idMemberMap.SetSerializer(new StringSerializer(representation: BsonType.ObjectId));
+                idMemberMap.SetIdGenerator(StringObjectIdGenerator.Instance);
+            }
+        }
+    }
+}

--- a/src/MongoDB.Bson/Serialization/Conventions/StringIdStoredAsObjectIdConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/StringIdStoredAsObjectIdConvention.cs
@@ -19,7 +19,10 @@ using MongoDB.Bson.Serialization.Serializers;
 namespace MongoDB.Bson.Serialization.Conventions
 {
     /// <summary>
-    /// A convention that sets representation of a string id class member to ObjectId in BSON with a StringObjectIdGenerator.
+    /// A convention that sets the representation of a string id class member to ObjectId in BSON with a StringObjectIdGenerator.
+    /// 
+    /// This convention is only responsible for setting the serializer and idGenerator. It is assumed that this convention runs after
+    /// other conventions that identify which member is the _id and that the _id has already been added to the class map.
     /// </summary>
     public class StringIdStoredAsObjectIdConvention : ConventionBase, IMemberMapConvention
     {
@@ -36,17 +39,19 @@ namespace MongoDB.Bson.Serialization.Conventions
                 return;
             }
 
+            var defaultStringSerializer = BsonSerializer.LookupSerializer(typeof(string));
+            if (memberMap.GetSerializer() != defaultStringSerializer)
+            {
+                return;
+            }
+
             if (memberMap.IdGenerator != null)
             {
                 return;
             }
 
-            var serializer = memberMap.GetSerializer();
-            if (serializer is StringSerializer stringSerializer && stringSerializer.Representation == BsonType.String)
-            {
-                memberMap.SetSerializer(new StringSerializer(representation: BsonType.ObjectId));
-                memberMap.SetIdGenerator(StringObjectIdGenerator.Instance);
-            }
+            memberMap.SetSerializer(new StringSerializer(representation: BsonType.ObjectId));
+            memberMap.SetIdGenerator(StringObjectIdGenerator.Instance);
         }
     }
 }

--- a/src/MongoDB.Bson/Serialization/Conventions/StringIdStoredAsObjectIdConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/StringIdStoredAsObjectIdConvention.cs
@@ -20,7 +20,6 @@ namespace MongoDB.Bson.Serialization.Conventions
 {
     /// <summary>
     /// A convention that sets the representation of a string id class member to ObjectId in BSON with a StringObjectIdGenerator.
-    /// 
     /// This convention is only responsible for setting the serializer and idGenerator. It is assumed that this convention runs after
     /// other conventions that identify which member is the _id and that the _id has already been added to the class map.
     /// </summary>

--- a/src/MongoDB.Bson/Serialization/Conventions/StringIdStoredAsObjectIdConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/StringIdStoredAsObjectIdConvention.cs
@@ -1,4 +1,19 @@
-﻿using MongoDB.Bson.Serialization.IdGenerators;
+﻿/* Copyright 2019-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using MongoDB.Bson.Serialization.IdGenerators;
 using MongoDB.Bson.Serialization.Serializers;
 
 namespace MongoDB.Bson.Serialization.Conventions
@@ -8,36 +23,29 @@ namespace MongoDB.Bson.Serialization.Conventions
     /// </summary>
     public class StringIdStoredAsObjectIdConvention : ConventionBase, IMemberMapConvention
     {
-        /// <summary>
-        /// Applies a post processing modification to the class map.
-        /// </summary>
-        /// <param name="memberMap">The BsonMemberMap map.</param>
-        /// <remarks>This method sets both the serializer and the IdGenerator on the id member field.</remarks>
+        /// <inheritdoc/>
         public void Apply(BsonMemberMap memberMap)
         {
-            var idMemberMap = memberMap.ClassMap?.IdMemberMap;
-
-            if (idMemberMap == null)
+            if (memberMap != memberMap.ClassMap.IdMemberMap)
             {
                 return;
             }
 
-            if (idMemberMap.MemberType != typeof(string))
+            if (memberMap.MemberType != typeof(string))
             {
                 return;
             }
 
-            if (idMemberMap.IdGenerator != null)
+            if (memberMap.IdGenerator != null)
             {
                 return;
             }
 
-            var idSerializer = idMemberMap.GetSerializer();
-
-            if (idSerializer is StringSerializer stringSerializer && stringSerializer.Representation == BsonType.String)
+            var serializer = memberMap.GetSerializer();
+            if (serializer is StringSerializer stringSerializer && stringSerializer.Representation == BsonType.String)
             {
-                idMemberMap.SetSerializer(new StringSerializer(representation: BsonType.ObjectId));
-                idMemberMap.SetIdGenerator(StringObjectIdGenerator.Instance);
+                memberMap.SetSerializer(new StringSerializer(representation: BsonType.ObjectId));
+                memberMap.SetIdGenerator(StringObjectIdGenerator.Instance);
             }
         }
     }

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/StringIdStoredAsObjectIdConventionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/StringIdStoredAsObjectIdConventionTests.cs
@@ -1,0 +1,95 @@
+﻿using Xunit;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.IdGenerators;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace MongoDB.Bson.Tests.Serialization.Conventions
+{
+    public class StringIdStoredAsObjectIdConventionTests
+    {
+        BsonMemberMap SampleMap<T>() => new BsonClassMap<T>(cm => cm.AutoMap()).GetMemberMap("Id");
+
+        [Fact]
+        public void Apply_StringId_SetsSerializer()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithStringId>();
+
+            target.Apply(subject);
+
+            Assert.IsType<StringSerializer>(subject.GetSerializer());
+        }
+
+        [Fact]
+        public void Apply_StringId_SetsIdGenerator()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithStringId>();
+
+            target.Apply(subject);
+
+            Assert.IsType<StringObjectIdGenerator>(subject.IdGenerator);
+        }
+
+        [Fact]
+        public void Apply_ExistingIdGenerator_DoesNotApply()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithStringId>();
+            subject.SetIdGenerator(CombGuidGenerator.Instance);
+
+            target.Apply(subject);
+
+            Assert.IsType<CombGuidGenerator>(subject.IdGenerator);
+        }
+
+        [Fact]
+        public void Apply_NotStringSerializer_DoesNotApply()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithStringId>();
+            subject.SetSerializer(new FakeStringSerializer());
+
+            target.Apply(subject);
+
+            Assert.IsType<FakeStringSerializer>(subject.GetSerializer());
+        }
+
+
+        [Fact]
+        public void Apply_IntId_LeavesSerializer()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithIntId>();
+
+            target.Apply(subject);
+
+            Assert.IsNotType<StringSerializer>(subject.GetSerializer());
+        }
+
+        [Fact]
+        public void Apply_IntId_NoIdGenerator()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithIntId>();
+
+            target.Apply(subject);
+
+            Assert.Null(subject.IdGenerator);
+        }
+
+
+        public class TestClassWithStringId { public string Id; }
+
+        public class TestClassWithIntId { public int Id; }
+
+        class FakeStringSerializer : SealedClassSerializerBase<string>
+        {
+            public BsonType Representation => BsonType.String;
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
This was a pull request submitted by Nuri Halperin as a result of a conversation we had at MongoDB World.

In theory we already supported this, but it turns out we only half supported it.