### PR TITLE
Rename testandpackage target to release and build docs also.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -40,10 +40,12 @@ var srcProjectNames = new[]
 };
 
 Task("Default")
-    .IsDependentOn("TestAndPackage");
+    .IsDependentOn("Test");
 
-Task("TestAndPackage")
+Task("Release")
+    .IsDependentOn("Build")
     .IsDependentOn("Test")
+    .IsDependentOn("Docs")
     .IsDependentOn("Package");    
    
 Task("Restore")


### PR DESCRIPTION
Old command to build a release:

    .\build.ps1 -target testandpackage

but this didn't build the docs, which are required for a release.

New command to build a release:

    .\build.ps1 -target release

which also builds the docs.