### PR TITLE
CSHARP-3240: ImmutableTypeClassMapConvention is ignoring some constructors

### DIFF
--- a/tests/MongoDB.Bson.Tests/Jira/CSharp1559Tests.cs
+++ b/tests/MongoDB.Bson.Tests/Jira/CSharp1559Tests.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Linq;
 using System.Reflection;
 using FluentAssertions;
 using MongoDB.Bson.Serialization;
@@ -26,18 +27,31 @@ namespace MongoDB.Bson.Tests.Jira
     public class CSharp1559Tests
     {
         [Theory]
-        [InlineData(typeof(DerivedWithoutSetter_BaseWithoutSetter))]
-        [InlineData(typeof(DerivedWithoutSetter_BaseWithPrivateSetterAndWithProtectedConstructor))]
-        [InlineData(typeof(DerivedWithoutSetterAndWithBsonElement_BaseWithoutSetterAndWithProtectedConstructor))]
-        [InlineData(typeof(DerivedWithoutSetterAndWithBsonElementAndWithPrivateConstructor_BaseWithoutSetter))]
-        [InlineData(typeof(DerivedWithoutSetterAndWithoutBsonElement_AbstractBaseWithoutSetterAndWithProtectedConstructor))]
-        [InlineData(typeof(DerivedWithoutSetterAndWithoutBsonElement_AbstractBaseWithoutSetter))]
-        [InlineData(typeof(DerivedWithPrivateSetterAndWithBsonElement_BaseWithoutSetter))]
-        public void Serialization_should_work_as_expected(Type testCaseType)
+        [InlineData(typeof(DerivedWithoutSetter_BaseWithoutSetter), new[] { 1, 2 }, "{ \"X\" : 1, \"Y\" : 2 }")]
+        [InlineData(typeof(DerivedWithoutSetter_BaseWithPrivateSetterAndWithProtectedConstructor), new[] { 1, 2 }, "{ \"X\" : 1, \"Y\" : 2 }")]
+        [InlineData(typeof(DerivedWithoutSetterAndWithBsonElement_BaseWithoutSetterAndWithProtectedConstructor), new[] { 1, 2 }, "{ \"X\" : 1, \"y\" : 2 }")]
+        [InlineData(typeof(DerivedWithoutSetterAndWithBsonElementAndWithPrivateConstructor_BaseWithoutSetter), new[] { 1, 2 }, "{ \"X\" : 1, \"y\" : 2 }")]
+        [InlineData(typeof(DerivedWithoutSetterAndWithoutBsonElement_AbstractBaseWithoutSetterAndWithProtectedConstructor), new[] { 1, 2 }, "{ \"X\" : 1, \"Y\" : 2 }")]
+        [InlineData(typeof(DerivedWithoutSetterAndWithoutBsonElement_AbstractBaseWithoutSetter), new[] { 1, 2 }, "{ \"X\" : 1, \"Y\" : 2 }")]
+        [InlineData(typeof(DerivedWithPrivateSetterAndWithBsonElement_BaseWithoutSetter), new[] { 1, 2 }, "{ \"X\" : 1, \"y\" : 2 }")]
+        [InlineData(typeof(DerivedImmutableWithMorePropertiesThanInConstructorAndWithBsonConstructorAttribute_AbstractBaseImmutable), new[] { 2 }, "{ \"Y\" : 2 }")]
+        [InlineData(typeof(DerivedImmutableWithMorePropertiesThanInConstructorAndWithBsonConstructorAttribute_AbstractBaseImmutableWithConstructor), new[] { 1, 2 }, "{ \"X\" : 1, \"Y\" : 2  }")]
+        [InlineData(typeof(DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonElementAttributeAndWithBsonConstructorAttribute_AbstractBaseImmutable), new[] { 2 }, "{ \"Y\" : 2 }")]
+        [InlineData(typeof(DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonElementAttributeAndWithBsonConstructorAttribute_AbstractBaseImmutableWithConstructor), new[] { 1, 2 }, "{ \"X\" : 1, \"Y\" : 2 }")]
+        [InlineData(typeof(DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonIgnoreAttribute_AbstractBaseImmutableWithAbstractProperty), new[] { 2 }, "{ \"Y\" : 2 }")]
+        [InlineData(typeof(DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonIgnoreAttribute_AbstractBaseImmutableWithConstructor), new[] { 1 }, "{ \"X\" : 1 }")]
+        [InlineData(typeof(ClassWithTwoConstructorsWhereTheFirstIsNotFullyMatchedAndTheSecondIsFullyMatched), new[] { 1, 2 }, "{ \"X\" : 1, \"Y\" : 2 }")]
+        [InlineData(typeof(ClassWithOneConstructorThatIsNotFullyMatched), new[] { 1, 2 }, "{ \"X\" : 1, \"Y\" : 2 }")]
+        public void Serialization_should_return_expected_result(Type testCaseType, int[] arguments, string expectedJson)
         {
-            var testCase = Activator.CreateInstance(testCaseType, 1, 2);
+            var testCase = Activator.CreateInstance(testCaseType, arguments.Select(a => (object)a).ToArray());
 
             var json = testCase.ToJson();
+            var actualBsonDocument = BsonDocument.Parse(json);
+            actualBsonDocument["_t"].ToString().Should().Be(testCaseType.Name);
+            actualBsonDocument.Remove("_t");
+            actualBsonDocument.Should().Be(BsonDocument.Parse(expectedJson));
+
             var result = BsonSerializer.Deserialize(json, testCaseType);
 
             var x = GetPropertyValue(result, "X");
@@ -233,6 +247,127 @@ namespace MongoDB.Bson.Tests.Jira
             }
 
             public int Y { get; }
+        }
+
+        public abstract class AbstractBaseImmutable
+        {
+            public int X { get; } = 1;
+        }
+
+        public class DerivedImmutableWithMorePropertiesThanInConstructorAndWithBsonConstructorAttribute_AbstractBaseImmutable : AbstractBaseImmutable
+        {
+            [BsonConstructor]
+            public DerivedImmutableWithMorePropertiesThanInConstructorAndWithBsonConstructorAttribute_AbstractBaseImmutable(int y)
+            {
+                Y = y;
+            }
+
+            public int Y { get; }
+        }
+
+        public class DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonElementAttributeAndWithBsonConstructorAttribute_AbstractBaseImmutable : AbstractBaseImmutable
+        {
+            [BsonConstructor]
+            public DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonElementAttributeAndWithBsonConstructorAttribute_AbstractBaseImmutable(int y)
+            {
+                Y = y;
+            }
+
+            [BsonElement]
+            public int Y { get; }
+        }
+
+        public abstract class AbstractBaseImmutableWithConstructor
+        {
+            public AbstractBaseImmutableWithConstructor(int x)
+            {
+                X = x;
+            }
+
+            public int X { get; } = 0; // should be overwritten
+        }
+
+        public class DerivedImmutableWithMorePropertiesThanInConstructorAndWithBsonConstructorAttribute_AbstractBaseImmutableWithConstructor : AbstractBaseImmutableWithConstructor
+        {
+            [BsonConstructor]
+            public DerivedImmutableWithMorePropertiesThanInConstructorAndWithBsonConstructorAttribute_AbstractBaseImmutableWithConstructor(int x, int y) : base(x)
+            {
+                Y = y;
+            }
+
+            public int Y { get; }
+        }
+
+        public class DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonElementAttributeAndWithBsonConstructorAttribute_AbstractBaseImmutableWithConstructor : AbstractBaseImmutableWithConstructor
+        {
+            [BsonConstructor]
+            public DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonElementAttributeAndWithBsonConstructorAttribute_AbstractBaseImmutableWithConstructor(int x, int y) : base(x)
+            {
+                Y = y;
+            }
+
+            [BsonElement]
+            public int Y { get; }
+        }
+
+        public class DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonIgnoreAttribute_AbstractBaseImmutableWithConstructor : AbstractBaseImmutableWithConstructor
+        {
+            public DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonIgnoreAttribute_AbstractBaseImmutableWithConstructor(int x) : base(x)
+            {
+            }
+
+            [BsonIgnore]
+            public int Y { get; } = 2;
+        }
+
+
+        public abstract class AbstractBaseImmutableWithAbstractProperty
+        {
+            [BsonIgnore]
+            public abstract int X { get; }
+        }
+
+        public class DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonIgnoreAttribute_AbstractBaseImmutableWithAbstractProperty : AbstractBaseImmutableWithAbstractProperty
+        {
+            public DerivedImmutableWithMorePropertiesThanInConstructorButWithBsonIgnoreAttribute_AbstractBaseImmutableWithAbstractProperty(int y)
+            {
+                Y = y;
+            }
+
+            [BsonIgnore]
+            public override int X { get; } = 1;
+
+            public int Y { get; } = 0; // should be overwritten
+        }
+
+        public class ClassWithTwoConstructorsWhereTheFirstIsNotFullyMatchedAndTheSecondIsFullyMatched
+        {
+            public int? X { get; }
+            public int? Y { get; }
+
+            public ClassWithTwoConstructorsWhereTheFirstIsNotFullyMatchedAndTheSecondIsFullyMatched(int? x)
+                : this(x, null)
+            {
+            }
+
+            public ClassWithTwoConstructorsWhereTheFirstIsNotFullyMatchedAndTheSecondIsFullyMatched(int? x, int? y)
+            {
+                X = x;
+                Y = y;
+            }
+        }
+
+        public class ClassWithOneConstructorThatIsNotFullyMatched
+        {
+            public int? X { get; }
+            public int? Y { get; }
+            public int? Z { get; }
+
+            public ClassWithOneConstructorThatIsNotFullyMatched(int? x, int? y)
+            {
+                X = x;
+                Y = y;
+            }
         }
     }
 }

--- a/tests/MongoDB.Bson.Tests/Jira/CSharp2984Tests.cs
+++ b/tests/MongoDB.Bson.Tests/Jira/CSharp2984Tests.cs
@@ -1,0 +1,73 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using FluentAssertions;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+using Xunit;
+
+namespace MongoDB.Bson.Tests.Jira
+{
+    // Note: including these tests as part of the work on CSHARP-3240 to verify that this also fixes CSHARP-2984
+
+    [BsonDiscriminator(RootClass = true)]
+    [BsonKnownTypes(typeof(Apple))]
+    [BsonIgnoreExtraElements]
+    public abstract class Fruit
+    {
+        [BsonIgnore]
+        public abstract string Color { get; }
+    }
+
+    [BsonIgnoreExtraElements]
+    public class Apple : Fruit
+    {
+        [BsonConstructor]
+        public Apple(int seeds)
+        {
+            Seeds = seeds;
+        }
+
+        public int Seeds { get; }
+
+        [BsonIgnore]
+        public override string Color => "Red";
+    }
+
+    public class CSharp2984Tests
+    {
+        [Fact]
+        public void Serialize_should_return_have_expected_result()
+        {
+            var subject = new Apple(1);
+
+            var result = subject.ToJson();
+
+            result.Should().Be("{ \"_t\" : [\"Fruit\", \"Apple\"], \"Seeds\" : 1 }");
+        }
+
+        [Fact]
+        public void Deserialize_should_return_expected_result()
+        {
+            var json = "{ \"_t\" : [\"Fruit\", \"Apple\"], \"Seeds\" : 1 }";
+
+            var result = BsonSerializer.Deserialize<Fruit>(json);
+
+            var apple = result.Should().BeOfType<Apple>().Subject;
+            apple.Seeds.Should().Be(1);
+            apple.Color.Should().Be("Red");
+        }
+    }
+}

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/ImmutableTypeClassMapConventionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/ImmutableTypeClassMapConventionTests.cs
@@ -121,7 +121,7 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             var classMap = BsonClassMap.LookupClassMap(typeof(TestClassC));
 
             classMap.DeclaredMemberMaps.Select(m => m.MemberName).Should().Equal("A", "B");
-            classMap.CreatorMaps.Count().Should().Be(1);
+            classMap.CreatorMaps.Count().Should().Be(2);
         }
 
         [Fact]
@@ -150,7 +150,7 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             var classMap = new BsonClassMap<TestClassC>();
             convention.Apply(classMap);
             Assert.True(classMap.HasCreatorMaps);
-            Assert.Equal(1, classMap.CreatorMaps.Count());
+            Assert.Equal(2, classMap.CreatorMaps.Count());
         }
 
         [Fact]


### PR DESCRIPTION
My suggested changes to ImmutableTypeClassMapConvention can be summarized succinctly as:

1. Consider all public constructors (not just the one with the most parameters)
2. Only map properties that match some constructor argument
