### PR TITLE
ExpressionToFilterTranslators code review changes.

### DIFF
--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Ast/Filters/AstAndFilter.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Ast/Filters/AstAndFilter.cs
@@ -72,7 +72,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Ast.Filters
                 var fieldPath = renderedFilter.GetElement(0).Name;
                 if (fieldPath.StartsWith("$"))
                 {
-                    // this case occurs when { $elem : { $op : args } } is rendered as { $op : args } inside an $elemMatch
+                    // this case occurs when { @<elem> : { $op : args } } is rendered as { $op : args } inside an $elemMatch, so fieldPath is an operator
                     if (renderedAsImplicitAnd.Contains(fieldPath))
                     {
                         return false;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Ast/Filters/AstElemMatchFilterOperation.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Ast/Filters/AstElemMatchFilterOperation.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Ast.Filters
 {
     internal sealed class AstElemMatchFilterOperation : AstFilterOperation
     {
-        private readonly AstFilter _filter; // note: using "$elem" to represent the implied element values
+        private readonly AstFilter _filter; // note: using "@<elem>" to represent the implied element values
 
         public AstElemMatchFilterOperation(AstFilter filter)
         {

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Ast/Filters/AstFieldOperationFilter.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Ast/Filters/AstFieldOperationFilter.cs
@@ -36,13 +36,13 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Ast.Filters
         public override BsonValue Render()
         {
             var fieldPath = _field.Path;
-            if (fieldPath == "$elem")
+            if (fieldPath == "@<elem>")
             {
                 return _operation.Render();
             }
-            if (fieldPath.StartsWith("$elem."))
+            if (fieldPath.StartsWith("@<elem>."))
             {
-                fieldPath = fieldPath.Substring(6);
+                fieldPath = fieldPath.Substring(8);
             }
 
             if (_operation is AstComparisonFilterOperation comparisonOperation &&
@@ -55,7 +55,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Ast.Filters
             if (
                 _operation is AstElemMatchFilterOperation elemMatchOperation &&
                 elemMatchOperation.Filter is AstFieldOperationFilter fieldOperationFilter &&
-                fieldOperationFilter.Field.Path == "$elem")
+                fieldOperationFilter.Field.Path == "@<elem>")
             {
                 if (fieldOperationFilter.Operation is AstComparisonFilterOperation elemMatchComparisonOperation &&
                     elemMatchComparisonOperation.Operator == AstComparisonFilterOperator.Eq &&

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Ast/Filters/AstFilterField.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Ast/Filters/AstFilterField.cs
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Ast.Filters
         {
             Ensure.IsNotNull(subFieldName, nameof(subFieldName));
 
-            if (_path == "$CURRENT")
+            if (_path == "@<current>")
             {
                 return new AstFilterField(subFieldName, subFieldSerializer);
             }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/AbsMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/AbsMethodToAggregationExpressionTranslator.cs
@@ -23,7 +23,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
 {
     internal static class AbsMethodToAggregationExpressionTranslator
     {
-        private static MethodInfo[] __absMethods =
+        private static readonly MethodInfo[] __absMethods =
         {
             MathMethod.AbsDecimal,
             MathMethod.AbsDouble,

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/AverageMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/AverageMethodToAggregationExpressionTranslator.cs
@@ -24,7 +24,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
 {
     internal static class AverageMethodToAggregationExpressionTranslator
     {
-        private static MethodInfo[] __averageMethods =
+        private static readonly MethodInfo[] __averageMethods =
         {
             EnumerableMethod.AverageDecimal,
             EnumerableMethod.AverageDecimalWithSelector,
@@ -48,7 +48,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             EnumerableMethod.AverageSingleWithSelector
         };
 
-        private static MethodInfo[] __averageWithSelectorMethods =
+        private static readonly MethodInfo[] __averageWithSelectorMethods =
         {
             EnumerableMethod.AverageDecimalWithSelector,
             EnumerableMethod.AverageDoubleWithSelector,

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/CountMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/CountMethodToAggregationExpressionTranslator.cs
@@ -26,8 +26,8 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
 {
     internal static class CountMethodToAggregationExpressionTranslator
     {
-        private static MethodInfo[] __countMethods;
-        private static MethodInfo[] __countWithPredicateMethods;
+        private static readonly MethodInfo[] __countMethods;
+        private static readonly MethodInfo[] __countWithPredicateMethods;
 
         static CountMethodToAggregationExpressionTranslator()
         {

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/StartsWithContainsOrEndsWithMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/StartsWithContainsOrEndsWithMethodToAggregationExpressionTranslator.cs
@@ -28,9 +28,9 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
 {
     internal static class StartsWithContainsOrEndsWithMethodToAggregationExpressionTranslator
     {
-        private static MethodInfo[] __startsWithContainsOrEndWithMethods;
-        private static MethodInfo[] __withComparisonTypeMethods;
-        private static MethodInfo[] __withIgnoreCaseAndCultureMethods;
+        private static readonly MethodInfo[] __startsWithContainsOrEndWithMethods;
+        private static readonly MethodInfo[] __withComparisonTypeMethods;
+        private static readonly MethodInfo[] __withIgnoreCaseAndCultureMethods;
 
         static StartsWithContainsOrEndsWithMethodToAggregationExpressionTranslator()
         {

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/SumMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/SumMethodToAggregationExpressionTranslator.cs
@@ -24,7 +24,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
 {
     internal static class SumMethodToAggregationExpressionTranslator
     {
-        private static MethodInfo[] __sumMethods =
+        private static readonly MethodInfo[] __sumMethods =
         {
             EnumerableMethod.SumDecimal,
             EnumerableMethod.SumDecimalWithSelector,

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/TrimMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/TrimMethodToAggregationExpressionTranslator.cs
@@ -25,7 +25,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
 {
     internal static class TrimMethodToAggregationExpressionTranslator
     {
-        private static MethodInfo[] __trimMethods;
+        private static readonly MethodInfo[] __trimMethods;
 
         static TrimMethodToAggregationExpressionTranslator()
         {

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/ArrayLengthComparisonExpressionToFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/ArrayLengthComparisonExpressionToFilterTranslator.cs
@@ -22,6 +22,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
 {
     internal static class ArrayLengthComparisonExpressionToFilterTranslator
     {
+        // caller is responsible for ensuring constant is on the right
         public static bool CanTranslate(Expression leftExpression, Expression rightExpression, out UnaryExpression arrayLengthExpression, out Expression sizeExpression)
         {
             if (leftExpression.NodeType == ExpressionType.ArrayLength)

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/BitMaskComparisonExpressionToFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/BitMaskComparisonExpressionToFilterTranslator.cs
@@ -31,6 +31,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
                 leftBinaryExpression.NodeType == ExpressionType.And;
         }
 
+        // caller is responsible for ensuring constant is on the right
         public static AstFilter Translate(
             TranslationContext context,
             Expression expression,

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/CompareToComparisonExpressionToFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/CompareToComparisonExpressionToFilterTranslator.cs
@@ -31,6 +31,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
                 IsCompareToMethod(leftMethodCallExpression.Method);
         }
 
+        // caller is responsible for ensuring constant is on the right
         public static AstFilter Translate(
             TranslationContext context,
             Expression expression,

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/CountComparisonExpressionToFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/CountComparisonExpressionToFilterTranslator.cs
@@ -25,6 +25,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
 {
     internal static class CountComparisonExpressionToFilterTranslator
     {
+        // caller is responsible for ensuring constant is on the right
         public static bool CanTranslate(Expression leftExpression, Expression rightExpression, out Expression enumerableExpression, out Expression sizeExpression)
         {
             if (leftExpression.NodeType == ExpressionType.MemberAccess)

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/ModuloComparisonExpressionToFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/ModuloComparisonExpressionToFilterTranslator.cs
@@ -23,6 +23,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
 {
     internal static class ModuloComparisonExpressionToFilterTranslator
     {
+        // caller is responsible for ensuring constant is on the right
         public static bool CanTranslate(Expression leftExpression, Expression rightExpression, out BinaryExpression moduloExpression, out Expression remainderExpression)
         {
             if (leftExpression.NodeType == ExpressionType.Modulo)
@@ -45,7 +46,22 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
             var divisorExpression = moduloExpression.Right;
             BsonValue divisor;
             BsonValue remainder;
-            if (divisorExpression.Type == typeof(int) && remainderExpression.Type == typeof(int))
+            if (divisorExpression.Type == typeof(decimal) && remainderExpression.Type == typeof(decimal))
+            {
+                divisor = divisorExpression.GetConstantValue<decimal>(containingExpression: moduloExpression);
+                remainder = remainderExpression.GetConstantValue<decimal>(containingExpression: expression);
+            }
+            else if (divisorExpression.Type == typeof(double) && remainderExpression.Type == typeof(double))
+            {
+                divisor = divisorExpression.GetConstantValue<double>(containingExpression: moduloExpression);
+                remainder = remainderExpression.GetConstantValue<double>(containingExpression: expression);
+            }
+            else if (divisorExpression.Type == typeof(float) && remainderExpression.Type == typeof(float))
+            {
+                divisor = divisorExpression.GetConstantValue<float>(containingExpression: moduloExpression);
+                remainder = remainderExpression.GetConstantValue<float>(containingExpression: expression);
+            }
+            else if (divisorExpression.Type == typeof(int) && remainderExpression.Type == typeof(int))
             {
                 divisor = divisorExpression.GetConstantValue<int>(containingExpression: moduloExpression);
                 remainder = remainderExpression.GetConstantValue<int>(containingExpression: expression);
@@ -54,6 +70,16 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
             {
                 divisor = divisorExpression.GetConstantValue<long>(containingExpression: moduloExpression);
                 remainder = remainderExpression.GetConstantValue<long>(containingExpression: expression);
+            }
+            else if (divisorExpression.Type == typeof(uint) && remainderExpression.Type == typeof(uint))
+            {
+                divisor = divisorExpression.GetConstantValue<uint>(containingExpression: moduloExpression);
+                remainder = remainderExpression.GetConstantValue<uint>(containingExpression: expression);
+            }
+            else if (divisorExpression.Type == typeof(ulong) && remainderExpression.Type == typeof(ulong))
+            {
+                divisor = (long)divisorExpression.GetConstantValue<ulong>(containingExpression: moduloExpression);
+                remainder = (long)remainderExpression.GetConstantValue<ulong>(containingExpression: expression);
             }
             else
             {

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/StringExpressionToRegexFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/StringExpressionToRegexFilterTranslator.cs
@@ -32,15 +32,15 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
     internal static class StringExpressionToRegexFilterTranslator
     {
         // private static fields
-        private static MethodInfo[] __indexOfAnyMethods;
-        private static MethodInfo[] __indexOfMethods;
-        private static MethodInfo[] __indexOfWithCharMethods;
-        private static MethodInfo[] __indexOfWithComparisonTypeMethods;
-        private static MethodInfo[] __indexOfWithCountMethods;
-        private static MethodInfo[] __indexOfWithStartIndexMethods;
-        private static MethodInfo[] __indexOfWithStringMethods;
-        private static MethodInfo[] __modifierMethods;
-        private static MethodInfo[] __translatableMethods;
+        private static readonly MethodInfo[] __indexOfAnyMethods;
+        private static readonly MethodInfo[] __indexOfMethods;
+        private static readonly MethodInfo[] __indexOfWithCharMethods;
+        private static readonly MethodInfo[] __indexOfWithComparisonTypeMethods;
+        private static readonly MethodInfo[] __indexOfWithCountMethods;
+        private static readonly MethodInfo[] __indexOfWithStartIndexMethods;
+        private static readonly MethodInfo[] __indexOfWithStringMethods;
+        private static readonly MethodInfo[] __modifierMethods;
+        private static readonly MethodInfo[] __translatableMethods;
 
         // static constructor
         static StringExpressionToRegexFilterTranslator()
@@ -135,7 +135,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
         }
 
         // public static methods
-        public static bool  CanTranslate(Expression expression)
+        public static bool CanTranslate(Expression expression)
         {
             if (expression is MethodCallExpression methodCallExpression)
             {
@@ -145,6 +145,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
             return false;
         }
 
+        // caller is responsible for ensuring constant is on the right
         public static bool CanTranslateComparisonExpression(Expression leftExpression, AstComparisonFilterOperator comparisonOperator, Expression rightExpression)
         {
             // (int)document.S[i] == c
@@ -193,6 +194,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
             throw new ExpressionNotSupportedException(expression);
         }
 
+        // caller is responsible for ensuring constant is on the right
         public static AstFilter TranslateComparisonExpression(TranslationContext context, Expression expression, Expression leftExpression, AstComparisonFilterOperator comparisonOperator, Expression rightExpression)
         {
             if (IsGetCharsComparison(leftExpression))
@@ -568,7 +570,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
                 var noEarlyMatchCount = comparand - startIndex;
                 if (noEarlyMatchCount > 0)
                 {
-                    pattern += $"[^{escapedSet}]{{{noEarlyMatchCount}}}"; // advance to comparand while verifing there are no earlier matches
+                    pattern += $"[^{escapedSet}]{{{noEarlyMatchCount}}}"; // advance to comparand while verifying there are no earlier matches
                 }
                 if (anyOf.Length == 1)
                 {

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/MethodTranslators/AllOrAnyMethodToFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/MethodTranslators/AllOrAnyMethodToFilterTranslator.cs
@@ -53,8 +53,8 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
                     var predicateLambda = (LambdaExpression)arguments[1];
                     var parameterExpression = predicateLambda.Parameters.Single();
                     var elementSerializer = ArraySerializerHelper.GetItemSerializer(field.Serializer);
-                    var parameterSymbol = new Symbol("$elem", elementSerializer);
-                    var predicateSymbolTable = new SymbolTable(parameterExpression, parameterSymbol); // $elem is the only symbol visible inside an $elemMatch
+                    var parameterSymbol = new Symbol("@<elem>", elementSerializer); // @<elem> represents the implied element 
+                    var predicateSymbolTable = new SymbolTable(parameterExpression, parameterSymbol); // @<elem> is the only symbol visible inside an $elemMatch
                     var predicateContext = new TranslationContext(predicateSymbolTable);
                     var predicateFilter = ExpressionToFilterTranslator.Translate(predicateContext, predicateLambda.Body, exprOk: false);
 
@@ -118,10 +118,10 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
                     var predicateLambda = (LambdaExpression)arguments[1];
                     var parameterExpression = predicateLambda.Parameters.Single();
                     var itemSerializer = ArraySerializerHelper.GetItemSerializer(sourceField.Serializer);
-                    var parameterSymbol = new Symbol("$elem", itemSerializer);
-                    var predicateSymbolTable = new SymbolTable(parameterExpression, parameterSymbol); // $elem is the only symbol visible inside an $elemMatch
+                    var parameterSymbol = new Symbol("@<elem>", itemSerializer); // @<elem> represents the implied element 
+                    var predicateSymbolTable = new SymbolTable(parameterExpression, parameterSymbol); // @<elem> is the only symbol visible inside an $elemMatch
                     var predicateContext = new TranslationContext(predicateSymbolTable);
-                    var whereFilter = ExpressionToFilterTranslator.Translate(predicateContext, predicateLambda.Body, exprOk : false);
+                    var whereFilter = ExpressionToFilterTranslator.Translate(predicateContext, predicateLambda.Body, exprOk: false);
                     var combinedFilter = AstFilter.Combine(sourceFilter, whereFilter);
 
                     return (sourceField, combinedFilter);

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/MethodTranslators/AllWithContainsInPredicateMethodToFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/MethodTranslators/AllWithContainsInPredicateMethodToFilterTranslator.cs
@@ -37,7 +37,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
 
                 if (IsContainsParameterExpression(predicateLambda.Body, predicateParameter, out var innerSourceExpression))
                 {
-                    // a.All(i => f.Contains(i)) where f is an array field and as is an array constant
+                    // a.All(i => f.Contains(i)) where f is an array field and a is an array constant
                     if (outerSourceExpression is ConstantExpression outerArrayConstantExpression)
                     {
                         arrayFieldExpression = innerSourceExpression;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/MethodTranslators/AnyWithContainsInPredicateMethodToFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/MethodTranslators/AnyWithContainsInPredicateMethodToFilterTranslator.cs
@@ -37,7 +37,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
 
                 if (IsContainsParameterExpression(predicateLambda.Body, predicateParameter, out var innerSourceExpression))
                 {
-                    // f.Any(i => a.Contains(i)) where f is an array field and as is an array constant
+                    // f.Any(i => a.Contains(i)) where f is an array field and a is an array constant
                     if (innerSourceExpression is ConstantExpression innerArrayConstantExpression)
                     {
                         arrayFieldExpression = outerSourceExpression;
@@ -45,7 +45,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
                         return true;
                     }
 
-                    // a.Any(i => f.Contains(i)) where f is an array field and as is an array constant
+                    // a.Any(i => f.Contains(i)) where f is an array field and a is an array constant
                     if (outerSourceExpression is ConstantExpression outerArrayConstantExpression)
                     {
                         arrayFieldExpression = innerSourceExpression;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/MethodTranslators/ContainsMethodToFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/MethodTranslators/ContainsMethodToFilterTranslator.cs
@@ -71,14 +71,13 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
 
         private static AstFilter Translate(TranslationContext context, Expression expression, Expression sourceExpression, Expression itemExpression)
         {
-            if (TypeImplementsIEnumerable(sourceExpression.Type, itemExpression.Type) &&
-                itemExpression.NodeType == ExpressionType.Constant)
+            if (itemExpression.NodeType == ExpressionType.Constant)
             {
                 var sourceField = ExpressionToFilterFieldTranslator.Translate(context, sourceExpression);
                 var itemSerializer = ArraySerializerHelper.GetItemSerializer(sourceField.Serializer);
                 var value = itemExpression.GetConstantValue<object>(containingExpression: expression);
                 var serializedValue = SerializationHelper.SerializeValue(itemSerializer, value);
-                return AstFilter.ElemMatch(sourceField, AstFilter.Eq(AstFilter.Field("$elem", itemSerializer), serializedValue));
+                return AstFilter.ElemMatch(sourceField, AstFilter.Eq(AstFilter.Field("@<elem>", itemSerializer), serializedValue)); // @<elem> represents the implied element 
             }
 
             var itemField = ExpressionToFilterFieldTranslator.Translate(context, itemExpression);

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/MethodTranslators/EqualsMethodToFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/MethodTranslators/EqualsMethodToFilterTranslator.cs
@@ -28,7 +28,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
             var method = expression.Method;
             var arguments = expression.Arguments;
 
-            if (method.Name == "Equals" & method.ReturnType == typeof(bool))
+            if (method.Name == "Equals" && method.ReturnType == typeof(bool))
             {
                 if (method.IsStatic)
                 {

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ToFilterFieldTranslators/GetItemMethodToFilterFieldTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ToFilterFieldTranslators/GetItemMethodToFilterFieldTranslator.cs
@@ -13,7 +13,6 @@
 * limitations under the License.
 */
 
-using System.Collections.ObjectModel;
 using System.Linq.Expressions;
 using System.Reflection;
 using MongoDB.Bson.Serialization;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ToFilterFieldTranslators/ParameterExpressionToFilterFieldTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ToFilterFieldTranslators/ParameterExpressionToFilterFieldTranslator.cs
@@ -27,7 +27,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
             var symbolTable = context.SymbolTable;
             if (symbolTable.TryGetSymbol(expression, out Symbol symbol))
             {
-                var fieldName = symbol == symbolTable.Current ? "$CURRENT" : symbol.Name;
+                var fieldName = symbol == symbolTable.Current ? "@<current>" : symbol.Name;
                 var fieldSerializer = symbol.Serializer;
                 var field = AstFilter.Field(fieldName, fieldSerializer);
 

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp1585Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp1585Tests.cs
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
             var parameter = expression.Parameters[0];
             var serializerRegistry = BsonSerializer.SerializerRegistry;
             var documentSerializer = serializerRegistry.GetSerializer<Document>();
-            var symbol = new Symbol("$CURRENT", documentSerializer);
+            var symbol = new Symbol("@<current>", documentSerializer);
             var symbolTable = new SymbolTable().WithSymbolAsCurrent(parameter, symbol);
             var context = new TranslationContext(symbolTable);
             var filter = ExpressionToFilterTranslator.Translate(context, expression.Body, exprOk: false);
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
             var ast = AstFilter.ElemMatch(
                 new AstFilterField("Details.A", BsonValueSerializer.Instance),
                 AstFilter.ElemMatch(
-                    new AstFilterField("$elem", BsonValueSerializer.Instance),
+                    new AstFilterField("@<elem>", BsonValueSerializer.Instance),
                     AstFilter.Regex(new AstFilterField("DeviceName", BsonValueSerializer.Instance), ".Name0.", "")));
 
             var rendered = ast.Render();

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Translators/ExpressionToFilterTranslators/ExpressionTranslators/ModuloComparisonExpressionToFilterTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Translators/ExpressionToFilterTranslators/ExpressionTranslators/ModuloComparisonExpressionToFilterTranslatorTests.cs
@@ -1,0 +1,213 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver.Linq.Linq3Implementation.Ast.Filters;
+using MongoDB.Driver.Linq.Linq3Implementation.Misc;
+using MongoDB.Driver.Linq.Linq3Implementation.Translators;
+using MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilterTranslators.ExpressionTranslators;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Translators.ExpressionToFilterTranslators.ExpressionTranslators
+{
+    public class ModuloComparisonExpressionToFilterTranslatorTests
+    {
+        [Fact]
+        public void Translate_should_return_expected_result_with_byte_arguments()
+        {
+            var (parameter, expression) = CreateExpression((C c) => c.Byte % 2 == 1);
+            var context = CreateContext(parameter);
+            var canTranslate = ModuloComparisonExpressionToFilterTranslator.CanTranslate(expression.Left, expression.Right, out var moduloExpression, out var remainderExpression);
+            canTranslate.Should().BeTrue();
+
+            var result = ModuloComparisonExpressionToFilterTranslator.Translate(context, expression, moduloExpression, remainderExpression);
+
+            Assert(result, "Byte", 2, 1);
+        }
+
+        [Fact]
+        public void Translate_should_return_expected_result_with_decimal_arguments()
+        {
+            var (parameter, expression) = CreateExpression((C c) => c.Decimal % 2 == 1);
+            var context = CreateContext(parameter);
+            var canTranslate = ModuloComparisonExpressionToFilterTranslator.CanTranslate(expression.Left, expression.Right, out var moduloExpression, out var remainderExpression);
+            canTranslate.Should().BeTrue();
+
+            var result = ModuloComparisonExpressionToFilterTranslator.Translate(context, expression, moduloExpression, remainderExpression);
+
+            Assert(result, "Decimal", 2M, 1M);
+        }
+
+        [Fact]
+        public void Translate_should_return_expected_result_with_double_arguments()
+        {
+            var (parameter, expression) = CreateExpression((C c) => c.Double % 2 == 1);
+            var context = CreateContext(parameter);
+            var canTranslate = ModuloComparisonExpressionToFilterTranslator.CanTranslate(expression.Left, expression.Right, out var moduloExpression, out var remainderExpression);
+            canTranslate.Should().BeTrue();
+
+            var result = ModuloComparisonExpressionToFilterTranslator.Translate(context, expression, moduloExpression, remainderExpression);
+
+            Assert(result, "Double", 2.0, 1.0);
+        }
+
+        [Fact]
+        public void Translate_should_return_expected_result_with_float_arguments()
+        {
+            var (parameter, expression) = CreateExpression((C c) => c.Float % 2 == 1);
+            var context = CreateContext(parameter);
+            var canTranslate = ModuloComparisonExpressionToFilterTranslator.CanTranslate(expression.Left, expression.Right, out var moduloExpression, out var remainderExpression);
+            canTranslate.Should().BeTrue();
+
+            var result = ModuloComparisonExpressionToFilterTranslator.Translate(context, expression, moduloExpression, remainderExpression);
+
+            Assert(result, "Float", 2.0F, 1.0F);
+        }
+
+        [Fact]
+        public void Translate_should_return_expected_result_with_int16_arguments()
+        {
+            var (parameter, expression) = CreateExpression((C c) => c.Int16 % 2 == 1);
+            var context = CreateContext(parameter);
+            var canTranslate = ModuloComparisonExpressionToFilterTranslator.CanTranslate(expression.Left, expression.Right, out var moduloExpression, out var remainderExpression);
+            canTranslate.Should().BeTrue();
+
+            var result = ModuloComparisonExpressionToFilterTranslator.Translate(context, expression, moduloExpression, remainderExpression);
+
+            Assert(result, "Int16", 2, 1);
+        }
+
+        [Fact]
+        public void Translate_should_return_expected_result_with_int32_arguments()
+        {
+            var (parameter, expression) = CreateExpression((C c) => c.Int32 % 2 == 1);
+            var context = CreateContext(parameter);
+            var canTranslate = ModuloComparisonExpressionToFilterTranslator.CanTranslate(expression.Left, expression.Right, out var moduloExpression, out var remainderExpression);
+            canTranslate.Should().BeTrue();
+
+            var result = ModuloComparisonExpressionToFilterTranslator.Translate(context, expression, moduloExpression, remainderExpression);
+
+            Assert(result, "Int32", 2, 1);
+        }
+
+        [Fact]
+        public void Translate_should_return_expected_result_with_int64_arguments()
+        {
+            var (parameter, expression) = CreateExpression((C c) => c.Int64 % 2 == 1);
+            var context = CreateContext(parameter);
+            var canTranslate = ModuloComparisonExpressionToFilterTranslator.CanTranslate(expression.Left, expression.Right, out var moduloExpression, out var remainderExpression);
+            canTranslate.Should().BeTrue();
+
+            var result = ModuloComparisonExpressionToFilterTranslator.Translate(context, expression, moduloExpression, remainderExpression);
+
+            Assert(result, "Int64", 2L, 1L);
+        }
+
+        [Fact]
+        public void Translate_should_return_expected_result_with_sbyte_arguments()
+        {
+            var (parameter, expression) = CreateExpression((C c) => c.SByte % 2 == 1);
+            var context = CreateContext(parameter);
+            var canTranslate = ModuloComparisonExpressionToFilterTranslator.CanTranslate(expression.Left, expression.Right, out var moduloExpression, out var remainderExpression);
+            canTranslate.Should().BeTrue();
+
+            var result = ModuloComparisonExpressionToFilterTranslator.Translate(context, expression, moduloExpression, remainderExpression);
+
+            Assert(result, "SByte", 2, 1);
+        }
+
+        [Fact]
+        public void Translate_should_return_expected_result_with_uint16_arguments()
+        {
+            var (parameter, expression) = CreateExpression((C c) => c.UInt16 % 2 == 1);
+            var context = CreateContext(parameter);
+            var canTranslate = ModuloComparisonExpressionToFilterTranslator.CanTranslate(expression.Left, expression.Right, out var moduloExpression, out var remainderExpression);
+            canTranslate.Should().BeTrue();
+
+            var result = ModuloComparisonExpressionToFilterTranslator.Translate(context, expression, moduloExpression, remainderExpression);
+
+            Assert(result, "UInt16", 2, 1);
+        }
+
+        [Fact]
+        public void Translate_should_return_expected_result_with_uint32_arguments()
+        {
+            var (parameter, expression) = CreateExpression((C c) => c.UInt32 % 2 == 1);
+            var context = CreateContext(parameter);
+            var canTranslate = ModuloComparisonExpressionToFilterTranslator.CanTranslate(expression.Left, expression.Right, out var moduloExpression, out var remainderExpression);
+            canTranslate.Should().BeTrue();
+
+            var result = ModuloComparisonExpressionToFilterTranslator.Translate(context, expression, moduloExpression, remainderExpression);
+
+            Assert(result, "UInt32", 2L, 1L);
+        }
+
+        [Fact]
+        public void Translate_should_return_expected_result_with_uint64_arguments()
+        {
+            var (parameter, expression) = CreateExpression((C c) => c.UInt64 % 2 == 1);
+            var context = CreateContext(parameter);
+            var canTranslate = ModuloComparisonExpressionToFilterTranslator.CanTranslate(expression.Left, expression.Right, out var moduloExpression, out var remainderExpression);
+            canTranslate.Should().BeTrue();
+
+            var result = ModuloComparisonExpressionToFilterTranslator.Translate(context, expression, moduloExpression, remainderExpression);
+
+            Assert(result, "UInt64", 2L, 1L);
+        }
+
+        private void Assert(AstFilter result, string path, BsonValue divisor, BsonValue remainder)
+        {
+            var fieldOperationFilter = result.Should().BeOfType<AstFieldOperationFilter>().Subject;
+            fieldOperationFilter.Field.Path.Should().Be(path);
+            var modFilterOperation = fieldOperationFilter.Operation.Should().BeOfType<AstModFilterOperation>().Subject;
+            modFilterOperation.Divisor.Should().Be(divisor);
+            modFilterOperation.Remainder.Should().Be(remainder);
+        }
+
+        private TranslationContext CreateContext(ParameterExpression parameter)
+        {
+            var serializer = BsonSerializer.LookupSerializer(parameter.Type);
+            var symbol = new Symbol(parameter.Name, serializer);
+            return new TranslationContext().WithSymbolAsCurrent(parameter, symbol);
+        }
+
+        private (ParameterExpression, BinaryExpression) CreateExpression<TField>(Expression<Func<TField, bool>> lambda)
+        {
+            var parameter = lambda.Parameters.Single();
+            var expression = (BinaryExpression)lambda.Body;
+            return (parameter, expression);
+        }
+
+        private class C
+        {
+            public byte Byte { get; set; }
+            public decimal Decimal { get; set; }
+            public double Double { get; set; }
+            public float Float { get; set; }
+            public short Int16 { get; set; }
+            public int Int32 { get; set; }
+            public long Int64 { get; set; }
+            public sbyte SByte { get; set; }
+            public ushort UInt16 { get; set; }
+            public uint UInt32 { get; set; }
+            public ulong UInt64 { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
> ExpressionToFilterTranslator.Translate uses exceptions for flow control
  not sure if there is a better way

As discussed I don't think this is flow control. It's more like a retry

> line 38 consider catch (ExpressionNotSupportedException) when (exprOk)

I think it's better to try the translation first to catch translation errors and only check UsesExpr later

> additional catch block around TranslateUsingAggregationOperators so we can throw an exception indicating that we were unable to translate using filters or $expr?

I think this is a good idea but I'm postponing it until we work on adding more context to error messages.
 
> LINQ3 placeholders shouldn't look like MQL variables - $$CURRENT, $elem, etc.
   Choose something unique such as <> or <> to make it clear that these placeholders don't translate into MQL variables ContainsMethodToFilterTranslator

Done

> private Translate calls TypeImplementsIEnumerable again

Fixed

> uses magic $elem placeholder

Changed to @\<elem>

> StringExpressionToRegexFilterTranslator private static fields can be made readonly

Done (and in other files also)

> StringExpressionToRegexFilterTranslator extra space between bool and CanTranslate

Fixed

> TranslateComparisonExpression only handles constant on the right
  Add comment noting that ComparisonExpressionToFilterTranslator.Translate flips the operands if constant is on the left, which is why we only need to consider constant on right

Done (in multiple other places where this applies as well)

> line 571 s/verifing/verifying/

Done

> EqualsMethodToFilterTranslator line 31 should be logical and not bitwise

Fixed

> AllWithContainsInPredicateMethodToFilterTranslator fix comment on line 40

Done

> AnyWithContainsInPredicateMethodToFilterTranslator fix comments on lines 40 and 48

Done

> ModuloComparisonExpressionToFilterTranslator only accepts int and long, but any numeric type is acceptable

Added code to handle other numeric types. Also added tests.

> FirstMethodToFilterFieldTranslator unused using

Fixed

> GetItemMethodToFilterFieldTranslator unused usings

Fixed

> MethodCallExpressionToFilterFieldTranslator
   First() but no Last()

It's not possible to support Last this way in a filter (note: First translates to `a.0` but `a.-1` does not work for Last)